### PR TITLE
refactor: Remove unnecessary and outdated code comments

### DIFF
--- a/src/kimai_mcp/client.py
+++ b/src/kimai_mcp/client.py
@@ -92,11 +92,10 @@ class KimaiClient:
         try:
             response = await self._client.request(method, endpoint, **kwargs)
             response.raise_for_status()
-            
-            # Handle empty responses
+
             if response.status_code == 204:
                 return {}
-                
+
             return response.json()
             
         except httpx.HTTPStatusError as e:
@@ -104,7 +103,6 @@ class KimaiClient:
             error_details: Optional[Any] = None
             try:
                 error_data = e.response.json()
-                # Extract message
                 message = error_data.get('message', str(e))
 
                 # Helper to prune empty dicts recursively
@@ -241,7 +239,6 @@ class KimaiClient:
                 not large_size
             )
             
-            # Convert datetime to string format or use string as-is
             if filters.begin:
                 if isinstance(filters.begin, datetime):
                     params['begin'] = filters.begin.replace(microsecond=0).isoformat()
@@ -303,22 +300,18 @@ class KimaiClient:
             
             # Fetch page
             data = await self._request("GET", "/timesheets", params=paginated_params)
-            
+
             if not data:
-                # No more results
                 break
                 
             all_timesheets.extend([TimesheetEntity(**item) for item in data])
-            
-            # Check if we got less than page_size results (last page)
+
             if len(data) < page_size:
                 break
                 
             page += 1
             
-            # Safety limit to prevent infinite loops
             if page > 100:
-                # Log warning or raise exception
                 fetched_all = False
                 break
         
@@ -350,18 +343,17 @@ class KimaiClient:
     
     async def create_timesheet(self, timesheet: TimesheetEditForm) -> TimesheetEntity:
         """Create a new timesheet.
-        
+
         Args:
             timesheet: Timesheet data
         """
         payload = timesheet.model_dump(exclude_none=True, by_alias=True)
-        
-        # Convert datetime to ISO format
+
         if timesheet.begin:
             payload['begin'] = timesheet.begin.replace(microsecond=0).isoformat()
         if timesheet.end:
             payload['end'] = timesheet.end.replace(microsecond=0).isoformat()
-        
+
         data = await self._request("POST", "/timesheets", json=payload)
         return TimesheetEntity(**data)
     
@@ -373,13 +365,12 @@ class KimaiClient:
             timesheet: Updated timesheet data
         """
         payload = timesheet.model_dump(exclude_none=True, by_alias=True)
-        
-        # Convert datetime to ISO format
+
         if timesheet.begin:
             payload['begin'] = timesheet.begin.replace(microsecond=0).isoformat()
         if timesheet.end:
             payload['end'] = timesheet.end.replace(microsecond=0).isoformat()
-        
+
         data = await self._request("PATCH", f"/timesheets/{timesheet_id}", json=payload)
         return TimesheetEntity(**data)
     
@@ -436,8 +427,7 @@ class KimaiClient:
         params = {}
         if filters:
             params = filters.model_dump(exclude_none=True, by_alias=True)
-            
-            # Convert date to string format
+
             if filters.start:
                 params['start'] = filters.start.isoformat()
             if filters.end:
@@ -459,8 +449,7 @@ class KimaiClient:
     async def create_project(self, project: ProjectEditForm) -> ProjectExtended:
         """Create a new project."""
         payload = project.model_dump(exclude_none=True, by_alias=True)
-        
-        # Convert datetime to ISO format
+
         if project.start:
             payload['start'] = project.start.isoformat()
         if project.end:
@@ -472,13 +461,12 @@ class KimaiClient:
     async def update_project(self, project_id: int, project: ProjectEditForm) -> ProjectExtended:
         """Update an existing project."""
         payload = project.model_dump(exclude_none=True, by_alias=True)
-        
-        # Convert date to ISO format
+
         if project.start:
             payload['start'] = project.start.isoformat()
         if project.end:
             payload['end'] = project.end.isoformat()
-        
+
         data = await self._request("PATCH", f"/projects/{project_id}", json=payload)
         return ProjectExtended(**data)
     
@@ -630,14 +618,14 @@ class KimaiClient:
     
     async def get_absences(self, filters: Optional[AbsenceFilter] = None) -> List[Absence]:
         """Get list of absences.
-        
+
         Args:
             filters: Absence filters
         """
         params = {}
         if filters:
             params = filters.model_dump(exclude_none=True, by_alias=True)
-        
+
         data = await self._request("GET", "/absences", params=params)
         return [Absence(**item) for item in data]
     
@@ -726,20 +714,19 @@ class KimaiClient:
     
     async def get_public_holidays(self, filters: Optional[PublicHolidayFilter] = None) -> List[PublicHoliday]:
         """Get list of public holidays.
-        
+
         Args:
             filters: Public holiday filters
         """
         params = {}
         if filters:
             params = filters.model_dump(exclude_none=True, by_alias=True)
-            
-            # Convert datetime to string format
+
             if filters.begin:
                 params['begin'] = filters.begin.date().isoformat()
             if filters.end:
                 params['end'] = filters.end.date().isoformat()
-        
+
         data = await self._request("GET", "/public-holidays", params=params)
         return [PublicHoliday(**item) for item in data]
     
@@ -752,13 +739,12 @@ class KimaiClient:
         params = {}
         if filters:
             params = filters.model_dump(exclude_none=True, by_alias=True)
-            
-            # Convert datetime to string format
+
             if filters.begin:
                 params['begin'] = filters.begin.date().isoformat()
             if filters.end:
                 params['end'] = filters.end.date().isoformat()
-        
+
         data = await self._request("GET", "/public-holidays/calendar", params=params)
         return [CalendarEvent(**item) for item in data]
     
@@ -906,8 +892,7 @@ class KimaiClient:
         params = {}
         if filters:
             params = filters.model_dump(exclude_none=True, by_alias=True)
-            
-            # Convert datetime to string format
+
             if filters.begin:
                 params['begin'] = filters.begin.replace(microsecond=0).isoformat()
             if filters.end:

--- a/src/kimai_mcp/models.py
+++ b/src/kimai_mcp/models.py
@@ -79,7 +79,7 @@ class TimesheetEntity(BaseModel):
     exported: bool = False
     billable: bool = True
     meta_fields: Optional[List[Dict[str, Any]]] = Field(None, alias="metaFields")
-    break_duration: Optional[int] = Field(None, alias="break")  # Break duration in seconds
+    break_duration: Optional[int] = Field(None, alias="break")
 
 
 class TimesheetEditForm(BaseModel):
@@ -92,10 +92,10 @@ class TimesheetEditForm(BaseModel):
     fixed_rate: Optional[float] = Field(None, alias="fixedRate")
     hourly_rate: Optional[float] = Field(None, alias="hourlyRate")
     user: Optional[int] = None
-    tags: Optional[str] = None  # Comma separated
+    tags: Optional[str] = None
     exported: Optional[bool] = None
     billable: Optional[bool] = None
-    break_duration: Optional[int] = Field(None, alias="break")  # Break duration in seconds
+    break_duration: Optional[int] = Field(None, alias="break")
 
 
 class TimesheetFilter(BaseModel):

--- a/src/kimai_mcp/tools/timesheet_analytics.py
+++ b/src/kimai_mcp/tools/timesheet_analytics.py
@@ -16,8 +16,7 @@ class TimesheetAnalytics:
                 "total_hours": 0,
                 "message": "No timesheets found for analysis"
             }
-        
-        # Initialize counters
+
         stats = {
             "total_entries": len(timesheets),
             "total_hours": 0.0,
@@ -48,50 +47,40 @@ class TimesheetAnalytics:
                 "projects": defaultdict(float),
                 "monthly_hours": defaultdict(float)
             })
-        
-        # Process each timesheet
+
         for ts in timesheets:
             if not ts.end:
                 stats["running_timers"] += 1
                 continue
                 
             stats["completed_entries"] += 1
-            
-            # Calculate duration
+
             duration_hours = (ts.end - ts.begin).total_seconds() / 3600
             stats["total_hours"] += duration_hours
-            
-            # Billable vs non-billable
+
             if ts.billable:
                 stats["billable_hours"] += duration_hours
             else:
                 stats["non_billable_hours"] += duration_hours
-            
-            # Track working days
+
             stats["working_days"].add(ts.begin.date())
-            
-            # Project distribution
+
             if ts.project:
                 stats["projects"][ts.project] += duration_hours
-            
-            # Activity distribution
+
             if ts.activity:
                 stats["activities"][ts.activity] += duration_hours
-            
-            # Daily aggregation
+
             date_key = ts.begin.date().isoformat()
             stats["daily_hours"][date_key] += duration_hours
-            
-            # Weekly aggregation
+
             year, week, _ = ts.begin.isocalendar()
             week_key = f"{year}-W{week:02d}"
             stats["weekly_hours"][week_key] += duration_hours
-            
-            # Monthly aggregation
+
             month_key = ts.begin.strftime("%Y-%m")
             stats["monthly_hours"][month_key] += duration_hours
-            
-            # Yearly aggregation
+
             year_key = ts.begin.year
             stats["yearly_hours"][year_key] += duration_hours
             
@@ -112,29 +101,24 @@ class TimesheetAnalytics:
                 
                 year_month_key = ts.begin.strftime("%m")
                 year_stats["monthly_hours"][year_month_key] += duration_hours
-            
-            # Hour of day distribution
+
             stats["hourly_distribution"][ts.begin.hour] += 1
-            
-            # Tag usage
+
             if ts.tags:
                 for tag in ts.tags:
                     stats["tags"][tag] += 1
-        
-        # Calculate derived metrics
+
         working_days_count = len(stats["working_days"])
         stats["working_days_count"] = working_days_count
         stats["avg_hours_per_day"] = (
             stats["total_hours"] / working_days_count 
             if working_days_count > 0 else 0
         )
-        
-        # Calculate overtime (assuming 8 hours per day standard)
+
         expected_hours = working_days_count * 8
         stats["overtime_hours"] = max(0, stats["total_hours"] - expected_hours)
         stats["expected_hours"] = expected_hours
-        
-        # Convert defaultdicts to regular dicts for JSON serialization
+
         stats["projects"] = dict(stats["projects"])
         stats["activities"] = dict(stats["activities"])
         stats["daily_hours"] = dict(stats["daily_hours"])
@@ -162,8 +146,7 @@ class TimesheetAnalytics:
                     "monthly_hours": dict(year_data["monthly_hours"])
                 }
             stats["years"] = processed_years
-        
-        # Remove the set (not JSON serializable)
+
         del stats["working_days"]
         
         # Add summary percentages
@@ -193,8 +176,7 @@ class TimesheetAnalytics:
                 "hour": peak_hour[0],
                 "entries": peak_hour[1]
             }
-        
-        # Round all float values
+
         stats["total_hours"] = round(stats["total_hours"], 2)
         stats["billable_hours"] = round(stats["billable_hours"], 2)
         stats["non_billable_hours"] = round(stats["non_billable_hours"], 2)

--- a/src/kimai_mcp/tools/timesheet_consolidated.py
+++ b/src/kimai_mcp/tools/timesheet_consolidated.py
@@ -242,7 +242,6 @@ async def _handle_timesheet_list(client: KimaiClient, filters: Dict) -> List[Tex
 
 
     if begin_datetime == end_datetime and begin_datetime.time() == datetime.min.time():
-        # AI Probably just specified a single day
         end_datetime = begin_datetime + timedelta(days=1)
     
     # Build filter


### PR DESCRIPTION
Remove ~40-50 unnecessary comments that were redundant with code:
- Removed obvious comments (e.g., "Handle empty responses", "Extract message")
- Removed repetitive datetime conversion comments (appeared 7+ times)
- Removed self-explanatory section markers in timesheet_analytics.py
- Fixed unprofessional comment in timesheet_consolidated.py
- Cleaned up redundant field comments in models.py

Improved code readability by keeping only valuable comments that:
- Explain complex business logic
- Document API contracts and enum values
- Clarify non-obvious implementation details