### PR TITLE
fix: add Cookie redirect header to prevent auth redirects

### DIFF
--- a/src/kimai_mcp/client.py
+++ b/src/kimai_mcp/client.py
@@ -57,7 +57,8 @@ class KimaiClient:
             headers={
                 "Authorization": f"Bearer {api_token}",
                 "Content-Type": "application/json",
-                "Accept": "application/json"
+                "Accept": "application/json",
+                "Cookie": "redirected=true"
             },
             timeout=timeout,
             verify=ssl_verify


### PR DESCRIPTION
## Summary
- Adds `Cookie: redirected=true` header to the httpx client
- Prevents Kimai instances behind reverse proxies from redirecting API requests to the login page

## Problem
Some Kimai setups (especially behind nginx/Apache reverse proxies) redirect API calls to the login page even with valid Bearer tokens. The `redirected=true` cookie signals that the request has already been through the proxy, preventing the redirect loop.

## Changes
- `src/kimai_mcp/client.py`: Added `"Cookie": "redirected=true"` to default headers