### PR TITLE
fix: Guard timesheet list against missing date filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kimai-mcp"
-version = "2.11.2"
+version = "2.11.3"
 description = "MCP server for Kimai time-tracking API integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/kimai_mcp/__init__.py
+++ b/src/kimai_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Kimai MCP Server - Model Context Protocol server for Kimai time-tracking API integration."""
 
-__version__ = "2.11.2"
+__version__ = "2.11.3"

--- a/src/kimai_mcp/tools/timesheet_consolidated.py
+++ b/src/kimai_mcp/tools/timesheet_consolidated.py
@@ -268,7 +268,12 @@ async def _handle_timesheet_list(client: KimaiClient, filters: Dict) -> List[Tex
                                 text=f"Error: Invalid date time format for field end '{filters['end']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")]
 
 
-    if begin_datetime == end_datetime and begin_datetime.time() == datetime.min.time():
+    if (
+        begin_datetime is not None
+        and end_datetime is not None
+        and begin_datetime == end_datetime
+        and begin_datetime.time() == datetime.min.time()
+    ):
         end_datetime = begin_datetime + timedelta(days=1)
     
     # Build filter

--- a/tests/test_timesheet_list.py
+++ b/tests/test_timesheet_list.py
@@ -1,0 +1,51 @@
+"""Regression tests for timesheet list handler (issue #12)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kimai_mcp.models import User
+from kimai_mcp.tools.timesheet_consolidated import _handle_timesheet_list
+
+
+def _mock_client() -> AsyncMock:
+    client = AsyncMock()
+    client.get_current_user.return_value = User(id=1, username="tester", enabled=True)
+    client.get_timesheets.return_value = ([], True, None)
+    return client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {},
+        {"user_scope": "self", "size": 5},
+        {"project": 1},
+    ],
+)
+async def test_list_without_date_filters_does_not_raise(filters):
+    """Regression for #12: list must not crash when begin/end are absent."""
+    client = _mock_client()
+
+    result = await _handle_timesheet_list(client, filters)
+
+    assert result and result[0].type == "text"
+    timesheet_filter = client.get_timesheets.await_args.args[0]
+    assert timesheet_filter.begin is None
+    assert timesheet_filter.end is None
+
+
+@pytest.mark.asyncio
+async def test_list_expands_same_day_midnight_range():
+    """When begin == end at midnight, end is bumped by one day (pre-existing behavior)."""
+    client = _mock_client()
+
+    await _handle_timesheet_list(
+        client,
+        {"begin": "2026-01-15T00:00:00", "end": "2026-01-15T00:00:00"},
+    )
+
+    timesheet_filter = client.get_timesheets.await_args.args[0]
+    assert timesheet_filter.begin.isoformat() == "2026-01-15T00:00:00"
+    assert timesheet_filter.end.isoformat() == "2026-01-16T00:00:00"


### PR DESCRIPTION
## Summary

- Fixes `'NoneType' object has no attribute 'time'` crash in the `timesheet` tool's `list` action when `begin`/`end` filters are omitted
- Bumps version to 2.11.3 in `pyproject.toml` and `src/kimai_mcp/__init__.py`
- Adds regression tests under `tests/` covering the reported filter variants and the preserved midnight-expansion behavior

## Root cause

`src/kimai_mcp/tools/timesheet_consolidated.py:271` relied on `None == None` short-circuiting before the `.time()` call, but Python evaluates both sides of `and` lazily only if the left is truthy — once the equality check returns `True`, `begin_datetime.time()` still gets called on `None`. The fix guards the condition on both datetimes being set before expanding a same-day-at-midnight range into a full day.

## Test plan

- [x] `pytest tests/test_timesheet_list.py -v` — 4/4 passing (empty filters, `{user_scope: self, size: 5}`, `{project: 1}`, plus midnight-range expansion)
- [ ] Manual smoke test via `uvx kimai-mcp` with `action=list` + empty filters against a live Kimai 2.31.0

Fixes #12