### PR TITLE
feat: Optional OIDC federated-login backend for the OAuth server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,server]"
       - name: Run linting
         run: ruff check src/
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Map each OIDC identity to a Kimai user by adding the `oidc_identity` field (matc
 
 Register **`<public-url>/oauth/oidc/callback`** as the redirect URI at your OIDC provider. Requires the `[server]` extra (`pip install "kimai-mcp[server]"`, which pulls in `PyJWT[crypto]`). The built-in slug login form is not exposed while the OIDC backend is active.
 
+When mapping by `email`, the `id_token` must also assert `email_verified: true`, otherwise the email claim is ignored — so a provider that lets users self-assert an unverified address cannot impersonate a mapped user. For providers that do not emit `email_verified` but are trusted to only issue verified emails, pass `--oidc-allow-unverified-email` (or `KIMAI_MCP_OIDC_ALLOW_UNVERIFIED_EMAIL=true`).
+
 📖 **[See full deployment guide →](DEPLOYMENT.md)**
 
 ## Command Line Options

--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ Access tokens are valid for 1 hour and refreshed automatically (refresh tokens u
 
 **Legacy endpoints:** The previous per-user URLs `/mcp/{slug}` still work but are deprecated. Migrate to the OAuth endpoint `/mcp` and start the server with `--disable-legacy-slugs`.
 
+#### OIDC federated login (optional)
+
+Instead of the built-in slug + `auth_secret` form, the Streamable HTTP server can delegate user authentication to any standard **OpenID Connect** provider (Microsoft Entra ID / Azure AD, Keycloak, Auth0, Google, Okta, …). The server stays the OAuth 2.1 authorization server toward Claude.ai (same opaque tokens, DCR and PKCE); it only federates the login step: `/authorize` redirects to your OIDC provider, the `id_token` is verified (signature via JWKS, `iss`/`aud`/`exp`/`nonce`), and the resulting identity is mapped to a configured user.
+
+```bash
+kimai-mcp-streamable \
+  --users-config ./config/users.json \
+  --public-url https://mcp.example.com \
+  --auth-backend oidc \
+  --oidc-issuer https://login.microsoftonline.com/<tenant-id>/v2.0 \
+  --oidc-client-id <client-id>
+# Confidential clients: set KIMAI_MCP_OIDC_CLIENT_SECRET (env preferred over the CLI flag).
+```
+
+Map each OIDC identity to a Kimai user by adding the `oidc_identity` field (matched case-insensitively against `--oidc-identity-claim`, default `email`):
+
+```json
+{
+  "x7Kp2mQ9wL4r": {
+    "kimai_url": "https://kimai.example.com",
+    "kimai_token": "api_token_for_alice",
+    "oidc_identity": "alice@example.com"
+  }
+}
+```
+
+Register **`<public-url>/oauth/oidc/callback`** as the redirect URI at your OIDC provider. Requires the `[server]` extra (`pip install "kimai-mcp[server]"`, which pulls in `PyJWT[crypto]`). The built-in slug login form is not exposed while the OIDC backend is active.
+
 📖 **[See full deployment guide →](DEPLOYMENT.md)**
 
 ## Command Line Options
@@ -113,6 +141,13 @@ Options for the Streamable HTTP server (`kimai-mcp-streamable`):
 | `--disable-legacy-slugs` | `KIMAI_MCP_DISABLE_LEGACY_SLUGS` | Disable the deprecated `/mcp/{slug}` endpoints |
 | `--trusted-proxy IP` | `KIMAI_MCP_TRUSTED_PROXIES` (comma-separated) | Reverse proxy IPs whose `X-Forwarded-For`/`X-Real-IP` headers are honored; may be given multiple times |
 | `--rate-limit-rpm N` | `RATE_LIMIT_RPM` | Maximum requests per minute per IP (default: 60, 0 to disable) |
+| `--auth-backend {local,oidc}` | `KIMAI_MCP_AUTH_BACKEND` | Login backend: `local` (built-in slug form, default) or `oidc` (federate to an external OIDC provider) |
+| `--oidc-issuer URL` | `KIMAI_MCP_OIDC_ISSUER` | OIDC issuer URL (required for `--auth-backend oidc`) |
+| `--oidc-client-id ID` | `KIMAI_MCP_OIDC_CLIENT_ID` | OIDC client ID (required for `--auth-backend oidc`) |
+| `--oidc-client-secret SECRET` | `KIMAI_MCP_OIDC_CLIENT_SECRET` | OIDC client secret (optional; public/PKCE-only if omitted — prefer the env var) |
+| `--oidc-scopes SCOPES` | `KIMAI_MCP_OIDC_SCOPES` | Requested scopes (default: `openid email profile`) |
+| `--oidc-identity-claim CLAIM` | `KIMAI_MCP_OIDC_IDENTITY_CLAIM` | id_token claim mapped to a user's `oidc_identity` (default: `email`) |
+| `--oidc-discovery-url URL` | `KIMAI_MCP_OIDC_DISCOVERY_URL` | Override the discovery URL (default: `<issuer>/.well-known/openid-configuration`) |
 
 ## 🛠️ Available Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 server = [
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
+    "PyJWT[crypto]>=2.8.0",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/src/kimai_mcp/oauth.py
+++ b/src/kimai_mcp/oauth.py
@@ -36,6 +36,7 @@ from mcp.server.auth.provider import (
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
+from .oidc import OIDCClient, OIDCConfig, OIDCError, OIDCLoginState
 from .user_config import UsersConfig, _env_key_for_slug
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ LOGIN_TXN_TTL_SECONDS = 600  # 10 minutes
 CLIENT_TTL_SECONDS = 30 * 24 * 3600  # 30 days
 
 LOGIN_PATH = "/oauth/login"
+OIDC_CALLBACK_PATH = "/oauth/oidc/callback"
 
 
 @dataclass
@@ -120,6 +122,7 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
         users_config: UsersConfig,
         public_url: str,
         state_file: Optional[Union[str, Path]] = None,
+        oidc_config: Optional[OIDCConfig] = None,
     ):
         """Initialize the provider.
 
@@ -128,10 +131,17 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
             public_url: Public base URL of the server (issuer), no trailing slash.
             state_file: Optional path to a JSON file used to persist registered
                 OAuth clients across restarts (tokens are always in-memory).
+            oidc_config: Optional OIDC relying-party config. When set, users
+                authenticate against an external OIDC provider instead of the
+                built-in slug + auth_secret login form.
         """
         self.users_config = users_config
         self.public_url = public_url.rstrip("/")
         self.state_file = Path(state_file) if state_file else None
+        # Federated OIDC login backend (None -> built-in local login form).
+        self.oidc: Optional[OIDCClient] = OIDCClient(oidc_config) if oidc_config else None
+        # Pending federated logins keyed by the OIDC `state` we sent to the IdP.
+        self._oidc_logins: Dict[str, OIDCLoginState] = {}
 
         self._clients: Dict[str, OAuthClientInformationFull] = {}
         # Last time each client was seen (registered or looked up). Used to
@@ -215,10 +225,27 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
     # ------------------------------------------------------------------
 
     async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
-        """Store the request and redirect the user agent to the login form."""
+        """Store the request and redirect the user agent to the login step.
+
+        Local backend -> the built-in HTML login form. OIDC backend -> the
+        external identity provider's authorization endpoint.
+        """
         txn = secrets.token_urlsafe(32)
         self._pending[txn] = PendingAuthorization(client_id=client.client_id or "", params=params)
-        return f"{self.public_url}{LOGIN_PATH}?txn={txn}"
+
+        if self.oidc is None:
+            return f"{self.public_url}{LOGIN_PATH}?txn={txn}"
+
+        # Federated OIDC: create per-login state/nonce/PKCE, then redirect to the IdP.
+        oidc_state = secrets.token_urlsafe(32)
+        login_state, code_challenge = self.oidc.make_login_state(txn)
+        self._oidc_logins[oidc_state] = login_state
+        return await self.oidc.build_authorization_url(
+            state=oidc_state,
+            nonce=login_state.nonce,
+            code_challenge=code_challenge,
+            redirect_uri=f"{self.public_url}{OIDC_CALLBACK_PATH}",
+        )
 
     # ------------------------------------------------------------------
     # Login form (HTML)
@@ -316,8 +343,104 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
         redirect_url = construct_redirect_uri(str(params.redirect_uri), code=code, state=params.state)
         return RedirectResponse(redirect_url, status_code=302, headers={"Cache-Control": "no-store"})
 
+    # ------------------------------------------------------------------
+    # Federated OIDC callback
+    # ------------------------------------------------------------------
+
+    def _get_oidc_login(self, state: Optional[str]) -> Optional[OIDCLoginState]:
+        """Pop a pending OIDC login by state (single-use); None if missing/expired."""
+        if not state:
+            return None
+        login = self._oidc_logins.pop(state, None)
+        if login is None or login.expired:
+            return None
+        return login
+
+    @staticmethod
+    def _oidc_error(message: str, status_code: int) -> Response:
+        return HTMLResponse(
+            f"<h1>Sign-in failed</h1><p>{html.escape(message)}</p>"
+            "<p>Please restart the authorization flow from your client.</p>",
+            status_code=status_code,
+        )
+
+    async def handle_oidc_callback(self, request: Request) -> Response:
+        """GET /oauth/oidc/callback - complete the federated login and issue an auth code."""
+        params = request.query_params
+        if params.get("error"):
+            # The IdP rejected the login; do not echo provider internals to the user.
+            logger.warning(f"OIDC provider returned error: {params.get('error')}")
+            return self._oidc_error("The identity provider denied the sign-in request.", 400)
+
+        login = self._get_oidc_login(params.get("state"))
+        if login is None:
+            return self._oidc_error("Invalid or expired sign-in state.", 400)
+
+        pending = self._get_pending(login.txn)
+        if pending is None:
+            return self._oidc_error("Invalid or expired authorization request.", 400)
+
+        code = params.get("code")
+        if not code:
+            return self._oidc_error("Missing authorization code from the identity provider.", 400)
+
+        assert self.oidc is not None  # routes() only mounts this handler when OIDC is enabled
+        try:
+            tokens = await self.oidc.exchange_code(
+                code=code,
+                code_verifier=login.code_verifier,
+                redirect_uri=f"{self.public_url}{OIDC_CALLBACK_PATH}",
+            )
+            id_token = tokens.get("id_token")
+            if not id_token:
+                raise OIDCError("token response did not contain an id_token")
+            claims = await self.oidc.validate_id_token(id_token, expected_nonce=login.nonce)
+        except OIDCError as e:
+            logger.warning(f"OIDC sign-in failed: {e}")
+            return self._oidc_error("Could not verify your identity with the identity provider.", 401)
+
+        identity = self.oidc.extract_identity(claims)
+        if not identity:
+            logger.warning("OIDC id_token had no usable identity claim")
+            return self._oidc_error("The identity provider did not return a usable identity.", 401)
+
+        match = self.users_config.get_user_by_oidc_identity(identity)
+        if match is None:
+            logger.warning(f"OIDC login: no Kimai user linked to identity '{identity}'")
+            return self._oidc_error("No Kimai account is linked to this identity.", 403)
+        slug, _user = match
+
+        # Success: consume the transaction and issue an authorization code, exactly
+        # as the local login form does, but with the OIDC-resolved slug as subject.
+        del self._pending[login.txn]
+        auth_params = pending.params
+
+        auth_code = secrets.token_urlsafe(32)
+        self._auth_codes[auth_code] = AuthorizationCode(
+            code=auth_code,
+            scopes=auth_params.scopes or [],
+            expires_at=time.time() + AUTH_CODE_TTL_SECONDS,
+            client_id=pending.client_id,
+            code_challenge=auth_params.code_challenge,
+            redirect_uri=auth_params.redirect_uri,
+            redirect_uri_provided_explicitly=auth_params.redirect_uri_provided_explicitly,
+            resource=auth_params.resource,
+            subject=slug,
+        )
+
+        logger.info(f"OIDC login successful for user '{slug}' (client {pending.client_id})")
+
+        # Open-redirect defense: redirect ONLY to the client redirect_uri the SDK
+        # already validated against the registered client during /authorize.
+        redirect_url = construct_redirect_uri(
+            str(auth_params.redirect_uri), code=auth_code, state=auth_params.state
+        )
+        return RedirectResponse(redirect_url, status_code=302, headers={"Cache-Control": "no-store"})
+
     def routes(self) -> list:
-        """Starlette routes for the login form."""
+        """Starlette routes for the active login backend."""
+        if self.oidc is not None:
+            return [Route(OIDC_CALLBACK_PATH, endpoint=self.handle_oidc_callback, methods=["GET"])]
         return [
             Route(LOGIN_PATH, endpoint=self.handle_login_page, methods=["GET"]),
             Route(LOGIN_PATH, endpoint=self.handle_login_submit, methods=["POST"]),
@@ -476,6 +599,10 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
 
         for txn in [t for t, p in self._pending.items() if p.expired]:
             del self._pending[txn]
+            removed += 1
+
+        for state in [s for s, login in self._oidc_logins.items() if login.expired]:
+            del self._oidc_logins[state]
             removed += 1
 
         for code in [c for c, ac in self._auth_codes.items() if ac.expires_at < now]:

--- a/src/kimai_mcp/oauth.py
+++ b/src/kimai_mcp/oauth.py
@@ -271,6 +271,27 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
             return None
         return pending
 
+    def _issue_auth_code(self, pending: PendingAuthorization, subject: str) -> RedirectResponse:
+        """Issue a single-use authorization code for an authenticated subject and
+        redirect back to the client. The caller must have already removed the
+        pending transaction. The redirect target is the SDK-validated client
+        redirect_uri from the stored request (open-redirect safe)."""
+        params = pending.params
+        code = secrets.token_urlsafe(32)
+        self._auth_codes[code] = AuthorizationCode(
+            code=code,
+            scopes=params.scopes or [],
+            expires_at=time.time() + AUTH_CODE_TTL_SECONDS,
+            client_id=pending.client_id,
+            code_challenge=params.code_challenge,
+            redirect_uri=params.redirect_uri,
+            redirect_uri_provided_explicitly=params.redirect_uri_provided_explicitly,
+            resource=params.resource,
+            subject=subject,
+        )
+        redirect_url = construct_redirect_uri(str(params.redirect_uri), code=code, state=params.state)
+        return RedirectResponse(redirect_url, status_code=302, headers={"Cache-Control": "no-store"})
+
     async def handle_login_page(self, request: Request) -> Response:
         """GET /oauth/login - render the login form."""
         txn = request.query_params.get("txn")
@@ -323,25 +344,8 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
 
         # Success: consume the transaction and issue an authorization code.
         del self._pending[txn]
-        params = pending.params
-
-        code = secrets.token_urlsafe(32)
-        self._auth_codes[code] = AuthorizationCode(
-            code=code,
-            scopes=params.scopes or [],
-            expires_at=time.time() + AUTH_CODE_TTL_SECONDS,
-            client_id=pending.client_id,
-            code_challenge=params.code_challenge,
-            redirect_uri=params.redirect_uri,
-            redirect_uri_provided_explicitly=params.redirect_uri_provided_explicitly,
-            resource=params.resource,
-            subject=username,
-        )
-
         logger.info(f"OAuth login successful for user '{username}' (client {pending.client_id})")
-
-        redirect_url = construct_redirect_uri(str(params.redirect_uri), code=code, state=params.state)
-        return RedirectResponse(redirect_url, status_code=302, headers={"Cache-Control": "no-store"})
+        return self._issue_auth_code(pending, username)
 
     # ------------------------------------------------------------------
     # Federated OIDC callback
@@ -406,36 +410,17 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
 
         match = self.users_config.get_user_by_oidc_identity(identity)
         if match is None:
+            # Detailed reason is logged server-side only; the response stays generic
+            # (consistent with the local login form's deliberate non-disclosure).
             logger.warning(f"OIDC login: no Kimai user linked to identity '{identity}'")
-            return self._oidc_error("No Kimai account is linked to this identity.", 403)
+            return self._oidc_error("Your account is not authorized for this application.", 403)
         slug, _user = match
 
-        # Success: consume the transaction and issue an authorization code, exactly
-        # as the local login form does, but with the OIDC-resolved slug as subject.
+        # Success: consume the transaction and issue an authorization code (same
+        # path as the local login form, with the OIDC-resolved slug as subject).
         del self._pending[login.txn]
-        auth_params = pending.params
-
-        auth_code = secrets.token_urlsafe(32)
-        self._auth_codes[auth_code] = AuthorizationCode(
-            code=auth_code,
-            scopes=auth_params.scopes or [],
-            expires_at=time.time() + AUTH_CODE_TTL_SECONDS,
-            client_id=pending.client_id,
-            code_challenge=auth_params.code_challenge,
-            redirect_uri=auth_params.redirect_uri,
-            redirect_uri_provided_explicitly=auth_params.redirect_uri_provided_explicitly,
-            resource=auth_params.resource,
-            subject=slug,
-        )
-
         logger.info(f"OIDC login successful for user '{slug}' (client {pending.client_id})")
-
-        # Open-redirect defense: redirect ONLY to the client redirect_uri the SDK
-        # already validated against the registered client during /authorize.
-        redirect_url = construct_redirect_uri(
-            str(auth_params.redirect_uri), code=auth_code, state=auth_params.state
-        )
-        return RedirectResponse(redirect_url, status_code=302, headers={"Cache-Control": "no-store"})
+        return self._issue_auth_code(pending, slug)
 
     def routes(self) -> list:
         """Starlette routes for the active login backend."""
@@ -647,3 +632,8 @@ class KimaiOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Ref
         if removed:
             logger.debug(f"OAuth cleanup removed {removed} expired entries")
         return removed
+
+    async def aclose(self) -> None:
+        """Release resources held by the OIDC client (if any)."""
+        if self.oidc is not None:
+            await self.oidc.aclose()

--- a/src/kimai_mcp/oidc.py
+++ b/src/kimai_mcp/oidc.py
@@ -1,0 +1,349 @@
+"""Generic, provider-agnostic OpenID Connect (OIDC) relying-party helper.
+
+This module lets the embedded OAuth server (``oauth.py``) authenticate end users
+against ANY standard OIDC provider (Azure AD / Entra ID, Keycloak, Auth0, Google,
+Okta, ...) during the Authorization-Code-with-PKCE flow. It performs ONLY the
+federated user-authentication step:
+
+1. redirect the browser to the provider's authorization endpoint,
+2. exchange the returned code for tokens at the provider's token endpoint,
+3. verify the ``id_token`` (signature via JWKS, ``iss``/``aud``/``exp``/``iat``
+   and ``nonce``), and
+4. extract the configured identity claim (e.g. ``email``).
+
+The MCP server keeps issuing its own opaque access/refresh tokens — this module
+never mints tokens for the MCP client. Provider endpoints are discovered via
+``<issuer>/.well-known/openid-configuration`` so nothing is hardcoded.
+
+Requires the ``[server]`` extra (``PyJWT[crypto]``) for id_token signature
+verification.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import httpx
+from pydantic import BaseModel, Field
+
+# NOTE: PyJWT (``jwt``) is only needed for id_token signature verification and is
+# part of the optional ``[server]`` extra. It is imported lazily inside the
+# methods that use it so that ``import kimai_mcp.oidc`` (and therefore the OAuth
+# server module) works on a base install without PyJWT.
+
+logger = logging.getLogger(__name__)
+
+# How long a federated login transaction (state/nonce/PKCE) stays valid.
+OIDC_LOGIN_TTL_SECONDS = 600  # 10 minutes
+# Caches for the provider discovery document and its signing keys.
+DISCOVERY_TTL_SECONDS = 3600  # 1 hour
+JWKS_TTL_SECONDS = 3600  # 1 hour
+# Asymmetric algorithms we are willing to accept for id_tokens. "none" and the
+# HMAC family are intentionally excluded (an attacker who knows the client_id
+# could otherwise forge HS256 tokens).
+DEFAULT_ALLOWED_ALGS = ["RS256", "RS384", "RS512", "ES256", "ES384", "PS256"]
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return a (code_verifier, code_challenge) PKCE pair using S256 (RFC 7636)."""
+    verifier = _b64url(secrets.token_bytes(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+class OIDCError(Exception):
+    """Base class for OIDC relying-party errors."""
+
+
+class OIDCDiscoveryError(OIDCError):
+    """Provider discovery or JWKS retrieval failed."""
+
+
+class OIDCTokenExchangeError(OIDCError):
+    """The authorization-code exchange at the token endpoint failed."""
+
+
+class OIDCValidationError(OIDCError):
+    """The id_token failed validation (signature, claims or nonce)."""
+
+
+class OIDCConfig(BaseModel):
+    """Configuration for the OIDC relying party.
+
+    Built from CLI flags / environment variables by the server. The redirect/
+    callback URL registered at the provider is the server's
+    ``<public-url>/oauth/oidc/callback`` and is supplied per request, not here.
+    """
+
+    issuer: str = Field(..., description="OIDC issuer URL, e.g. https://login.microsoftonline.com/<tenant>/v2.0")
+    client_id: str = Field(..., description="OAuth client ID registered at the provider")
+    client_secret: Optional[str] = Field(
+        None, description="Client secret for confidential clients; omit for public (PKCE-only) clients"
+    )
+    scopes: List[str] = Field(
+        default_factory=lambda: ["openid", "email", "profile"],
+        description="Scopes requested from the provider (must include 'openid')",
+    )
+    identity_claims: List[str] = Field(
+        default_factory=lambda: ["email", "preferred_username", "upn"],
+        description="Ordered id_token claims to try when resolving the user identity",
+    )
+    allowed_algorithms: List[str] = Field(
+        default_factory=lambda: list(DEFAULT_ALLOWED_ALGS),
+        description="Permitted id_token signing algorithms (never 'none'/HS*)",
+    )
+    discovery_url: Optional[str] = Field(
+        None, description="Override for the discovery document URL (default: <issuer>/.well-known/openid-configuration)"
+    )
+    clock_skew_seconds: int = Field(60, description="Allowed clock skew when validating exp/iat")
+
+
+@dataclass
+class OIDCProviderMetadata:
+    """The subset of the discovery document we use."""
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    jwks_uri: str
+
+
+@dataclass
+class OIDCLoginState:
+    """Per-login state bridging /authorize -> provider -> /oauth/oidc/callback.
+
+    Stored server-side keyed by ``state``; single-use and short-lived.
+    """
+
+    txn: str  # links back to the OAuth provider's PendingAuthorization
+    nonce: str
+    code_verifier: str
+    created_at: float = field(default_factory=time.time)
+
+    @property
+    def expired(self) -> bool:
+        return time.time() - self.created_at > OIDC_LOGIN_TTL_SECONDS
+
+
+class OIDCClient:
+    """Minimal async OIDC relying party: discovery, auth URL, code exchange, id_token validation."""
+
+    def __init__(self, config: OIDCConfig, http_client: Optional[httpx.AsyncClient] = None):
+        self.config = config
+        self._external_client = http_client is not None
+        self._http = http_client
+        self._metadata: Optional[OIDCProviderMetadata] = None
+        self._metadata_at: float = 0.0
+        self._jwks: Optional[dict] = None
+        self._jwks_at: float = 0.0
+
+    @property
+    def _client(self) -> httpx.AsyncClient:
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=15.0)
+        return self._http
+
+    async def aclose(self) -> None:
+        if self._http is not None and not self._external_client:
+            await self._http.aclose()
+            self._http = None
+
+    @property
+    def _discovery_url(self) -> str:
+        return self.config.discovery_url or f"{self.config.issuer.rstrip('/')}/.well-known/openid-configuration"
+
+    # ------------------------------------------------------------------
+    # Discovery + JWKS (cached)
+    # ------------------------------------------------------------------
+
+    async def discover(self) -> OIDCProviderMetadata:
+        """Fetch (and cache) the provider's discovery document."""
+        if self._metadata is not None and time.monotonic() - self._metadata_at < DISCOVERY_TTL_SECONDS:
+            return self._metadata
+        try:
+            resp = await self._client.get(self._discovery_url)
+            resp.raise_for_status()
+            doc = resp.json()
+        except Exception as e:
+            if self._metadata is not None:  # stale-if-error: keep serving the cached doc
+                logger.warning(f"OIDC discovery refresh failed, using cached metadata: {e}")
+                return self._metadata
+            raise OIDCDiscoveryError(f"Failed to fetch OIDC discovery document: {e}") from e
+
+        # Per the OIDC spec the discovered issuer MUST match the configured one;
+        # this prevents a swapped/spoofed discovery document.
+        if str(doc.get("issuer", "")).rstrip("/") != self.config.issuer.rstrip("/"):
+            raise OIDCDiscoveryError(
+                f"Discovery issuer mismatch: configured '{self.config.issuer}', document '{doc.get('issuer')}'"
+            )
+        try:
+            metadata = OIDCProviderMetadata(
+                issuer=doc["issuer"],
+                authorization_endpoint=doc["authorization_endpoint"],
+                token_endpoint=doc["token_endpoint"],
+                jwks_uri=doc["jwks_uri"],
+            )
+        except KeyError as e:
+            raise OIDCDiscoveryError(f"Discovery document missing required field: {e}") from e
+        self._metadata, self._metadata_at = metadata, time.monotonic()
+        return metadata
+
+    async def _get_jwks(self, force_refresh: bool = False) -> dict:
+        if (
+            not force_refresh
+            and self._jwks is not None
+            and time.monotonic() - self._jwks_at < JWKS_TTL_SECONDS
+        ):
+            return self._jwks
+        metadata = await self.discover()
+        try:
+            resp = await self._client.get(metadata.jwks_uri)
+            resp.raise_for_status()
+            jwks = resp.json()
+        except Exception as e:
+            if self._jwks is not None:
+                logger.warning(f"JWKS refresh failed, using cached keys: {e}")
+                return self._jwks
+            raise OIDCDiscoveryError(f"Failed to fetch JWKS: {e}") from e
+        self._jwks, self._jwks_at = jwks, time.monotonic()
+        return jwks
+
+    # ------------------------------------------------------------------
+    # Login flow
+    # ------------------------------------------------------------------
+
+    def make_login_state(self, txn: str) -> tuple[OIDCLoginState, str]:
+        """Create a per-login state object and the matching PKCE code_challenge."""
+        verifier, challenge = generate_pkce_pair()
+        state = OIDCLoginState(txn=txn, nonce=secrets.token_urlsafe(32), code_verifier=verifier)
+        return state, challenge
+
+    async def build_authorization_url(
+        self, *, state: str, nonce: str, code_challenge: str, redirect_uri: str
+    ) -> str:
+        """Build the provider authorization URL (Authorization Code + PKCE S256)."""
+        metadata = await self.discover()
+        params = {
+            "client_id": self.config.client_id,
+            "response_type": "code",
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(self.config.scopes),
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        return f"{metadata.authorization_endpoint}?{httpx.QueryParams(params)}"
+
+    async def exchange_code(self, *, code: str, code_verifier: str, redirect_uri: str) -> Dict[str, Any]:
+        """Exchange an authorization code for tokens. Returns the raw token response."""
+        metadata = await self.discover()
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": self.config.client_id,
+            "code_verifier": code_verifier,
+        }
+        if self.config.client_secret:
+            data["client_secret"] = self.config.client_secret
+        try:
+            resp = await self._client.post(metadata.token_endpoint, data=data)
+        except Exception as e:
+            raise OIDCTokenExchangeError(f"Token endpoint request failed: {e}") from e
+        if resp.status_code != 200:
+            # Do not log the response body verbatim (may echo the code); log status only.
+            raise OIDCTokenExchangeError(f"Token endpoint returned HTTP {resp.status_code}")
+        return resp.json()
+
+    async def validate_id_token(self, id_token: str, *, expected_nonce: str) -> Dict[str, Any]:
+        """Verify the id_token signature and claims; return the validated claims.
+
+        Verifies: JWKS signature, ``iss`` == discovered issuer, ``aud`` == client_id,
+        ``exp``/``iat`` (with leeway), required claims, and ``nonce``.
+        """
+        import jwt  # lazy: part of the [server] extra (PyJWT[crypto])
+
+        try:
+            header = jwt.get_unverified_header(id_token)
+        except jwt.InvalidTokenError as e:
+            raise OIDCValidationError(f"Malformed id_token header: {e}") from e
+
+        alg = header.get("alg")
+        if alg not in self.config.allowed_algorithms:
+            raise OIDCValidationError(f"Disallowed id_token signing algorithm: {alg!r}")
+        kid = header.get("kid")
+
+        signing_key = await self._resolve_signing_key(kid)
+        metadata = await self.discover()
+        try:
+            claims = jwt.decode(
+                id_token,
+                key=signing_key.key,
+                algorithms=self.config.allowed_algorithms,
+                audience=self.config.client_id,
+                issuer=metadata.issuer,
+                leeway=self.config.clock_skew_seconds,
+                options={"require": ["exp", "iat", "iss", "aud"]},
+            )
+        except jwt.InvalidTokenError as e:
+            raise OIDCValidationError(f"id_token validation failed: {e}") from e
+
+        # PyJWT does not check the OIDC nonce; do it here, constant-time.
+        token_nonce = claims.get("nonce", "")
+        if not expected_nonce or not hmac.compare_digest(str(token_nonce), expected_nonce):
+            raise OIDCValidationError("id_token nonce mismatch")
+        return claims
+
+    async def _resolve_signing_key(self, kid: Optional[str]):
+        """Find the JWK matching ``kid`` (refresh JWKS once on a miss for key rotation)."""
+        from jwt import PyJWKSet  # lazy: part of the [server] extra
+
+        for force in (False, True):
+            jwks = await self._get_jwks(force_refresh=force)
+            try:
+                key_set = PyJWKSet.from_dict(jwks)
+            except Exception as e:
+                raise OIDCValidationError(f"Invalid JWKS: {e}") from e
+            if kid is None:
+                if len(key_set.keys) == 1:
+                    return key_set.keys[0]
+            else:
+                for key in key_set.keys:
+                    if key.key_id == kid:
+                        return key
+            if force:
+                break
+        raise OIDCValidationError(f"No JWKS signing key for kid={kid!r}")
+
+    # ------------------------------------------------------------------
+    # Identity extraction
+    # ------------------------------------------------------------------
+
+    def extract_identity(self, claims: Dict[str, Any]) -> Optional[str]:
+        """Resolve the federated identity from the configured claim fallback list.
+
+        For username-style fallback claims (``preferred_username``/``upn``) a value
+        is only accepted if it looks like an email (contains ``@``), to avoid
+        matching an opaque username against an email-keyed user mapping.
+        """
+        for claim in self.config.identity_claims:
+            value = claims.get(claim)
+            if not isinstance(value, str) or not value.strip():
+                continue
+            value = value.strip()
+            if claim in ("preferred_username", "upn") and "@" not in value:
+                continue
+            return value
+        return None

--- a/src/kimai_mcp/oidc.py
+++ b/src/kimai_mcp/oidc.py
@@ -99,6 +99,14 @@ class OIDCConfig(BaseModel):
         default_factory=lambda: ["email", "preferred_username", "upn"],
         description="Ordered id_token claims to try when resolving the user identity",
     )
+    require_verified_email: bool = Field(
+        True,
+        description=(
+            "When the matched identity claim is 'email', require the id_token's "
+            "'email_verified' claim to be true. Disable only for providers that "
+            "do not emit email_verified but are trusted to assert verified emails."
+        ),
+    )
     allowed_algorithms: List[str] = Field(
         default_factory=lambda: list(DEFAULT_ALLOWED_ALGS),
         description="Permitted id_token signing algorithms (never 'none'/HS*)",
@@ -265,7 +273,10 @@ class OIDCClient:
         if resp.status_code != 200:
             # Do not log the response body verbatim (may echo the code); log status only.
             raise OIDCTokenExchangeError(f"Token endpoint returned HTTP {resp.status_code}")
-        return resp.json()
+        try:
+            return resp.json()
+        except ValueError as e:  # non-JSON body on a 200 (e.g. a misconfigured proxy)
+            raise OIDCTokenExchangeError("Token endpoint returned a non-JSON response") from e
 
     async def validate_id_token(self, id_token: str, *, expected_nonce: str) -> Dict[str, Any]:
         """Verify the id_token signature and claims; return the validated claims.
@@ -299,6 +310,13 @@ class OIDCClient:
             )
         except jwt.InvalidTokenError as e:
             raise OIDCValidationError(f"id_token validation failed: {e}") from e
+
+        # azp (authorized party): per OIDC Core 3.1.3.7, if present it MUST equal
+        # our client_id. PyJWT only checks that client_id is contained in `aud`,
+        # which is insufficient for multi-audience tokens.
+        azp = claims.get("azp")
+        if azp is not None and azp != self.config.client_id:
+            raise OIDCValidationError("id_token azp does not match client_id")
 
         # PyJWT does not check the OIDC nonce; do it here, constant-time.
         token_nonce = claims.get("nonce", "")
@@ -337,6 +355,11 @@ class OIDCClient:
         For username-style fallback claims (``preferred_username``/``upn``) a value
         is only accepted if it looks like an email (contains ``@``), to avoid
         matching an opaque username against an email-keyed user mapping.
+
+        The ``email`` claim is only honored when the id_token also asserts
+        ``email_verified`` is true (unless ``require_verified_email`` is disabled),
+        so an IdP that lets users self-assert an unverified address cannot be used
+        to impersonate a user mapped by email.
         """
         for claim in self.config.identity_claims:
             value = claims.get(claim)
@@ -345,5 +368,12 @@ class OIDCClient:
             value = value.strip()
             if claim in ("preferred_username", "upn") and "@" not in value:
                 continue
+            if claim == "email" and self.config.require_verified_email:
+                if claims.get("email_verified") is not True:
+                    logger.warning(
+                        "OIDC: ignoring 'email' claim because 'email_verified' is not true "
+                        "(set require_verified_email=false / --oidc-allow-unverified-email to override)"
+                    )
+                    continue
             return value
         return None

--- a/src/kimai_mcp/streamable_http_server.py
+++ b/src/kimai_mcp/streamable_http_server.py
@@ -48,6 +48,7 @@ from mcp.types import Tool, TextContent
 
 from .client import KimaiClient, KimaiAPIError
 from .oauth import KimaiOAuthProvider
+from .oidc import OIDCConfig
 from .server import __version__, format_api_error
 from .user_config import UsersConfig, UserConfig
 from .security import (
@@ -298,6 +299,7 @@ class StreamableHTTPMCPServer:
         trusted_proxies: Optional[List[str]] = None,
         disable_legacy_slugs: bool = False,
         oauth_state_file: Optional[str] = None,
+        oidc_config: Optional[OIDCConfig] = None,
     ):
         """Initialize the server.
 
@@ -313,6 +315,9 @@ class StreamableHTTPMCPServer:
                 X-Real-IP headers may be trusted.
             disable_legacy_slugs: Disable the deprecated /mcp/{user_slug} routes.
             oauth_state_file: Optional JSON file to persist registered OAuth clients.
+            oidc_config: Optional OIDC relying-party config. When set, the OAuth
+                login step federates to an external OIDC provider instead of the
+                built-in slug + auth_secret form.
         """
         self.users_config = users_config
         self.host = host
@@ -338,6 +343,7 @@ class StreamableHTTPMCPServer:
             users_config=users_config,
             public_url=self.public_url,
             state_file=oauth_state_file,
+            oidc_config=oidc_config,
         )
 
         # Rate limiting configuration
@@ -660,6 +666,54 @@ def create_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # OIDC federated login backend (optional; default is the built-in slug login)
+    parser.add_argument(
+        "--auth-backend",
+        choices=["local", "oidc"],
+        default=None,
+        help=(
+            "Login backend: 'local' (built-in slug + auth_secret form, default) or "
+            "'oidc' (federate to an external OIDC provider). "
+            "Or set KIMAI_MCP_AUTH_BACKEND."
+        ),
+    )
+    parser.add_argument(
+        "--oidc-issuer",
+        metavar="URL",
+        help="OIDC issuer URL (required for --auth-backend oidc; or KIMAI_MCP_OIDC_ISSUER)",
+    )
+    parser.add_argument(
+        "--oidc-client-id",
+        metavar="ID",
+        help="OIDC client ID (required for --auth-backend oidc; or KIMAI_MCP_OIDC_CLIENT_ID)",
+    )
+    parser.add_argument(
+        "--oidc-client-secret",
+        metavar="SECRET",
+        help=(
+            "OIDC client secret for confidential clients (optional; public/PKCE-only if omitted). "
+            "Prefer the KIMAI_MCP_OIDC_CLIENT_SECRET env var over the CLI flag."
+        ),
+    )
+    parser.add_argument(
+        "--oidc-scopes",
+        metavar="SCOPES",
+        help="OIDC scopes, space- or comma-separated (default: 'openid email profile'; or KIMAI_MCP_OIDC_SCOPES)",
+    )
+    parser.add_argument(
+        "--oidc-identity-claim",
+        metavar="CLAIM",
+        help=(
+            "id_token claim used to map to a user's oidc_identity (default: email; "
+            "or KIMAI_MCP_OIDC_IDENTITY_CLAIM)"
+        ),
+    )
+    parser.add_argument(
+        "--oidc-discovery-url",
+        metavar="URL",
+        help="Override the OIDC discovery URL (default: <issuer>/.well-known/openid-configuration)",
+    )
+
     # Security settings
     parser.add_argument(
         "--rate-limit-rpm",
@@ -689,6 +743,49 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     return parser
+
+
+def _build_oidc_config(args: argparse.Namespace) -> Optional[OIDCConfig]:
+    """Build an OIDCConfig from CLI/env if the oidc backend is selected, else None.
+
+    Raises ValueError on a misconfigured oidc backend (handled by main()).
+    """
+    backend = (args.auth_backend or os.getenv("KIMAI_MCP_AUTH_BACKEND") or "local").lower()
+    if backend != "oidc":
+        return None
+
+    issuer = args.oidc_issuer or os.getenv("KIMAI_MCP_OIDC_ISSUER")
+    client_id = args.oidc_client_id or os.getenv("KIMAI_MCP_OIDC_CLIENT_ID")
+    missing = [
+        name for name, val in (("--oidc-issuer", issuer), ("--oidc-client-id", client_id)) if not val
+    ]
+    if missing:
+        raise ValueError(
+            f"--auth-backend oidc requires {', '.join(missing)} "
+            f"(or the corresponding KIMAI_MCP_OIDC_* environment variables)"
+        )
+
+    client_secret = args.oidc_client_secret or os.getenv("KIMAI_MCP_OIDC_CLIENT_SECRET")
+    discovery_url = args.oidc_discovery_url or os.getenv("KIMAI_MCP_OIDC_DISCOVERY_URL")
+    identity_claim = args.oidc_identity_claim or os.getenv("KIMAI_MCP_OIDC_IDENTITY_CLAIM")
+    scopes_raw = args.oidc_scopes or os.getenv("KIMAI_MCP_OIDC_SCOPES")
+
+    kwargs: Dict[str, object] = {"issuer": issuer, "client_id": client_id}
+    if client_secret:
+        kwargs["client_secret"] = client_secret
+    if discovery_url:
+        kwargs["discovery_url"] = discovery_url
+    if scopes_raw:
+        scopes = [s for s in re.split(r"[,\s]+", scopes_raw.strip()) if s]
+        if scopes:
+            kwargs["scopes"] = scopes
+    if identity_claim:
+        # The configured claim leads the fallback list (email/preferred_username/upn).
+        fallbacks = [c for c in ["email", "preferred_username", "upn"] if c != identity_claim]
+        kwargs["identity_claims"] = [identity_claim, *fallbacks]
+
+    logger.info(f"OIDC auth backend enabled (issuer: {issuer})")
+    return OIDCConfig(**kwargs)
 
 
 def main() -> int:
@@ -721,6 +818,8 @@ def main() -> int:
     )
 
     try:
+        oidc_config = _build_oidc_config(args)
+
         # Load users config
         users_config = UsersConfig.load(args.users_config)
         logger.info(f"Loaded configuration for {len(users_config.users)} user(s)")
@@ -735,6 +834,7 @@ def main() -> int:
             trusted_proxies=trusted_proxies,
             disable_legacy_slugs=disable_legacy_slugs,
             oauth_state_file=oauth_state_file,
+            oidc_config=oidc_config,
         )
         server.run()
         return 0

--- a/src/kimai_mcp/streamable_http_server.py
+++ b/src/kimai_mcp/streamable_http_server.py
@@ -454,6 +454,8 @@ class StreamableHTTPMCPServer:
             with contextlib.suppress(asyncio.CancelledError):
                 await cleanup_task
             await self.cleanup_users()
+            with contextlib.suppress(Exception):
+                await self.oauth_provider.aclose()
 
     async def health_check(self, request: Request) -> JSONResponse:
         """Health check endpoint.
@@ -713,6 +715,15 @@ def create_parser() -> argparse.ArgumentParser:
         metavar="URL",
         help="Override the OIDC discovery URL (default: <issuer>/.well-known/openid-configuration)",
     )
+    parser.add_argument(
+        "--oidc-allow-unverified-email",
+        action="store_true",
+        help=(
+            "Accept the OIDC 'email' claim even when 'email_verified' is not true. "
+            "Only enable for providers that do not emit email_verified but are trusted "
+            "to assert verified emails (or set KIMAI_MCP_OIDC_ALLOW_UNVERIFIED_EMAIL=true)"
+        ),
+    )
 
     # Security settings
     parser.add_argument(
@@ -770,6 +781,10 @@ def _build_oidc_config(args: argparse.Namespace) -> Optional[OIDCConfig]:
     identity_claim = args.oidc_identity_claim or os.getenv("KIMAI_MCP_OIDC_IDENTITY_CLAIM")
     scopes_raw = args.oidc_scopes or os.getenv("KIMAI_MCP_OIDC_SCOPES")
 
+    allow_unverified_email = args.oidc_allow_unverified_email or (
+        os.getenv("KIMAI_MCP_OIDC_ALLOW_UNVERIFIED_EMAIL", "").lower() in ("1", "true", "yes")
+    )
+
     kwargs: Dict[str, object] = {"issuer": issuer, "client_id": client_id}
     if client_secret:
         kwargs["client_secret"] = client_secret
@@ -780,9 +795,12 @@ def _build_oidc_config(args: argparse.Namespace) -> Optional[OIDCConfig]:
         if scopes:
             kwargs["scopes"] = scopes
     if identity_claim:
-        # The configured claim leads the fallback list (email/preferred_username/upn).
-        fallbacks = [c for c in ["email", "preferred_username", "upn"] if c != identity_claim]
+        # The configured claim leads OIDCConfig's default fallback list.
+        default_claims = OIDCConfig.model_fields["identity_claims"].default_factory()
+        fallbacks = [c for c in default_claims if c != identity_claim]
         kwargs["identity_claims"] = [identity_claim, *fallbacks]
+    if allow_unverified_email:
+        kwargs["require_verified_email"] = False
 
     logger.info(f"OIDC auth backend enabled (issuer: {issuer})")
     return OIDCConfig(**kwargs)

--- a/src/kimai_mcp/user_config.py
+++ b/src/kimai_mcp/user_config.py
@@ -36,6 +36,14 @@ class UserConfig(BaseModel):
             "auth_secret cannot authenticate via OAuth."
         ),
     )
+    oidc_identity: Optional[str] = Field(
+        None,
+        description=(
+            "Identity value from the OIDC provider (e.g. the user's email) that "
+            "maps to this user when --auth-backend=oidc. Matched case-insensitively "
+            "against the configured --oidc-identity-claim."
+        ),
+    )
 
     @field_validator("kimai_url")
     @classmethod
@@ -84,8 +92,9 @@ class UsersConfig(BaseModel):
         return v
 
     @staticmethod
-    def _apply_env_auth_secrets(users: Dict[str, UserConfig]) -> None:
-        """Apply per-user auth secrets from KIMAI_USER_<NAME>_AUTH_SECRET env vars.
+    def _apply_env_overrides(users: Dict[str, UserConfig]) -> None:
+        """Apply per-user env-var overrides (KIMAI_USER_<NAME>_AUTH_SECRET /
+        KIMAI_USER_<NAME>_OIDC_IDENTITY).
 
         Environment variables take precedence over values from the config file.
         """
@@ -94,6 +103,10 @@ class UsersConfig(BaseModel):
             if env_secret:
                 config.auth_secret = env_secret
                 logger.info(f"Loaded auth_secret for user '{slug}' from environment")
+            env_identity = os.getenv(_env_key_for_slug(slug, "OIDC_IDENTITY"))
+            if env_identity:
+                config.oidc_identity = env_identity
+                logger.info(f"Loaded oidc_identity for user '{slug}' from environment")
 
     @classmethod
     def from_file(cls, path: Union[str, Path]) -> "UsersConfig":
@@ -144,7 +157,7 @@ class UsersConfig(BaseModel):
         if not users:
             raise ValueError("No users configured in config file")
 
-        cls._apply_env_auth_secrets(users)
+        cls._apply_env_overrides(users)
         return cls(users=users)
 
     @classmethod
@@ -181,7 +194,7 @@ class UsersConfig(BaseModel):
                     logger.info(f"Loaded config for user '{slug}' from USERS_CONFIG")
                 if not users:
                     raise ValueError("No valid users configured in USERS_CONFIG")
-                cls._apply_env_auth_secrets(users)
+                cls._apply_env_overrides(users)
                 return cls(users=users)
             except json.JSONDecodeError as e:
                 raise ValueError(f"Invalid JSON in USERS_CONFIG: {e}") from e
@@ -205,12 +218,14 @@ class UsersConfig(BaseModel):
 
                 ssl_key = f"{prefix}{slug.upper()}_SSL_VERIFY"
                 auth_secret_key = f"{prefix}{slug.upper()}_AUTH_SECRET"
+                oidc_identity_key = f"{prefix}{slug.upper()}_OIDC_IDENTITY"
 
                 users[slug] = UserConfig(
                     kimai_url=value,
                     kimai_token=token,
                     ssl_verify=os.getenv(ssl_key, "true"),
                     auth_secret=os.getenv(auth_secret_key),
+                    oidc_identity=os.getenv(oidc_identity_key),
                 )
                 logger.info(f"Loaded config for user '{slug}' from env vars")
 
@@ -250,6 +265,16 @@ class UsersConfig(BaseModel):
     def get_user(self, slug: str) -> Optional[UserConfig]:
         """Get configuration for a specific user."""
         return self.users.get(slug)
+
+    def get_user_by_oidc_identity(self, value: str) -> Optional[tuple[str, UserConfig]]:
+        """Return (slug, UserConfig) whose oidc_identity matches value (case-insensitive)."""
+        if not value:
+            return None
+        norm = value.strip().lower()
+        for slug, config in self.users.items():
+            if config.oidc_identity and config.oidc_identity.strip().lower() == norm:
+                return slug, config
+        return None
 
     def list_users(self) -> list[str]:
         """List all configured user slugs."""

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -629,3 +629,176 @@ def test_cleanup_removes_client_with_expired_secret(users_config):
 
     provider.cleanup_expired()
     assert "secret-client" not in provider._clients
+
+
+# ---------------------------------------------------------------------------
+# OIDC federated login backend (integration)
+# ---------------------------------------------------------------------------
+
+from kimai_mcp.oidc import OIDCConfig, OIDCLoginState  # noqa: E402
+
+OIDC_EMAIL = "alice@firma.de"
+
+
+def _make_fake_oidc(email: str):
+    """Build a network-free fake OIDCClient that resolves to ``email``."""
+
+    class _FakeOIDC:
+        def __init__(self, config):
+            self.config = config
+
+        def make_login_state(self, txn):
+            return OIDCLoginState(txn=txn, nonce="fixed-nonce", code_verifier="oidc-verifier"), "oidc-challenge"
+
+        async def build_authorization_url(self, *, state, nonce, code_challenge, redirect_uri):
+            return f"https://idp.test/authorize?state={state}&nonce={nonce}&code_challenge={code_challenge}"
+
+        async def exchange_code(self, *, code, code_verifier, redirect_uri):
+            return {"id_token": "fake-id-token", "access_token": "fake"}
+
+        async def validate_id_token(self, id_token, *, expected_nonce):
+            return {"email": email, "nonce": expected_nonce}
+
+        def extract_identity(self, claims):
+            return claims.get("email")
+
+        async def aclose(self):
+            pass
+
+    return _FakeOIDC
+
+
+@pytest.fixture
+def oidc_users_config() -> UsersConfig:
+    return UsersConfig(
+        users={
+            USER_SLUG: UserConfig(
+                kimai_url="https://kimai.example.com",
+                kimai_token="token-1",
+                oidc_identity=OIDC_EMAIL,
+            )
+        }
+    )
+
+
+def _oidc_authorize(http: TestClient, client_id: str, challenge: str, state: str = "st4te") -> str:
+    """GET /authorize on an OIDC-backed server; return the state sent to the IdP."""
+    resp = http.get(
+        "/authorize",
+        params={
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": REDIRECT_URI,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302, resp.text
+    location = resp.headers["location"]
+    assert location.startswith("https://idp.test/authorize"), location
+    return parse_qs(urlparse(location).query)["state"][0]
+
+
+def test_oidc_full_flow_end_to_end(make_client, oidc_users_config, monkeypatch):
+    monkeypatch.setattr("kimai_mcp.oauth.OIDCClient", _make_fake_oidc(OIDC_EMAIL))
+    http = make_client(
+        users_config=oidc_users_config,
+        oidc_config=OIDCConfig(issuer="https://idp.test", client_id="cid"),
+    )
+    client_info = register_client(http)
+    verifier, challenge = pkce_pair()
+    oidc_state = _oidc_authorize(http, client_info["client_id"], challenge)
+
+    resp = http.get(
+        "/oauth/oidc/callback",
+        params={"code": "idp-code", "state": oidc_state},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302, resp.text
+    location = resp.headers["location"]
+    assert location.startswith(REDIRECT_URI)
+    query = parse_qs(urlparse(location).query)
+    assert query["state"][0] == "st4te"
+    code = query["code"][0]
+
+    resp = http.post(
+        "/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+            "client_id": client_info["client_id"],
+            "code_verifier": verifier,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    access_token = resp.json()["access_token"]
+
+    # The opaque-token path is unchanged: an OIDC-authenticated user reaches /mcp.
+    resp = http.post(
+        "/mcp",
+        json=INIT_PAYLOAD,
+        headers={**MCP_HEADERS, "Authorization": f"Bearer {access_token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert "mcp-session-id" in {k.lower() for k in resp.headers}
+
+
+def test_oidc_local_login_form_not_mounted(make_client, oidc_users_config, monkeypatch):
+    monkeypatch.setattr("kimai_mcp.oauth.OIDCClient", _make_fake_oidc(OIDC_EMAIL))
+    http = make_client(
+        users_config=oidc_users_config,
+        oidc_config=OIDCConfig(issuer="https://idp.test", client_id="cid"),
+    )
+    # In OIDC mode the slug+secret form is not exposed.
+    resp = http.get("/oauth/login?txn=whatever", follow_redirects=False)
+    assert resp.status_code == 404
+
+
+def test_oidc_callback_unmatched_identity_is_forbidden(make_client, oidc_users_config, monkeypatch):
+    monkeypatch.setattr("kimai_mcp.oauth.OIDCClient", _make_fake_oidc("stranger@elsewhere.de"))
+    http = make_client(
+        users_config=oidc_users_config,
+        oidc_config=OIDCConfig(issuer="https://idp.test", client_id="cid"),
+    )
+    client_info = register_client(http)
+    _, challenge = pkce_pair()
+    oidc_state = _oidc_authorize(http, client_info["client_id"], challenge)
+
+    resp = http.get(
+        "/oauth/oidc/callback",
+        params={"code": "idp-code", "state": oidc_state},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403, resp.text
+    assert "location" not in resp.headers
+
+
+def test_oidc_callback_invalid_state_rejected(make_client, oidc_users_config, monkeypatch):
+    monkeypatch.setattr("kimai_mcp.oauth.OIDCClient", _make_fake_oidc(OIDC_EMAIL))
+    http = make_client(
+        users_config=oidc_users_config,
+        oidc_config=OIDCConfig(issuer="https://idp.test", client_id="cid"),
+    )
+    resp = http.get(
+        "/oauth/oidc/callback",
+        params={"code": "idp-code", "state": "never-issued-state"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_oidc_callback_provider_error_rejected(make_client, oidc_users_config, monkeypatch):
+    monkeypatch.setattr("kimai_mcp.oauth.OIDCClient", _make_fake_oidc(OIDC_EMAIL))
+    http = make_client(
+        users_config=oidc_users_config,
+        oidc_config=OIDCConfig(issuer="https://idp.test", client_id="cid"),
+    )
+    resp = http.get(
+        "/oauth/oidc/callback",
+        params={"error": "access_denied", "error_description": "user cancelled"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400, resp.text

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -114,10 +114,26 @@ def test_pkce_pair_is_s256():
     assert challenge == expected
 
 
-def test_extract_identity_prefers_email():
+def test_extract_identity_prefers_verified_email():
     cfg = OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID)
     cl = OIDCClient(cfg)
-    assert cl.extract_identity({"email": "a@b.de", "preferred_username": "x"}) == "a@b.de"
+    claims = {"email": "a@b.de", "email_verified": True, "preferred_username": "x@y.de"}
+    assert cl.extract_identity(claims) == "a@b.de"
+
+
+def test_extract_identity_skips_unverified_email():
+    cfg = OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID)
+    cl = OIDCClient(cfg)
+    # email_verified missing -> email ignored; preferred_username (no @) skipped -> None
+    assert cl.extract_identity({"email": "a@b.de", "preferred_username": "plain"}) is None
+    # email_verified false -> email ignored, falls back to upn (has @)
+    assert cl.extract_identity({"email": "a@b.de", "email_verified": False, "upn": "u@b.de"}) == "u@b.de"
+
+
+def test_extract_identity_allows_unverified_email_when_disabled():
+    cfg = OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID, require_verified_email=False)
+    cl = OIDCClient(cfg)
+    assert cl.extract_identity({"email": "a@b.de"}) == "a@b.de"
 
 
 def test_extract_identity_username_fallback_requires_at():
@@ -206,6 +222,20 @@ async def test_exchange_code_error_status(httpx_mock):
     await cl.aclose()
 
 
+@pytest.mark.asyncio
+async def test_exchange_code_non_json_200_is_wrapped(httpx_mock):
+    # A 200 with a non-JSON body (e.g. a misconfigured proxy) must raise
+    # OIDCTokenExchangeError, not an unhandled JSONDecodeError.
+    cl = make_client(httpx_mock, add_jwks=False)
+    httpx_mock.add_response(
+        url=TOKEN_ENDPOINT, method="POST", status_code=200,
+        content=b"<html>not json</html>", headers={"content-type": "text/html"},
+    )
+    with pytest.raises(OIDCTokenExchangeError):
+        await cl.exchange_code(code="abc", code_verifier="ver", redirect_uri="https://m/cb")
+    await cl.aclose()
+
+
 # ---------------------------------------------------------------------------
 # id_token validation
 # ---------------------------------------------------------------------------
@@ -216,6 +246,24 @@ async def test_validate_id_token_happy_path(httpx_mock):
     cl = make_client(httpx_mock)
     claims = await cl.validate_id_token(make_id_token(), expected_nonce="the-nonce")
     assert claims["email"] == "alice@firma.de"
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_azp_mismatch(httpx_mock):
+    cl = make_client(httpx_mock)
+    token = make_id_token(extra={"azp": "some-other-client"})
+    with pytest.raises(OIDCValidationError):
+        await cl.validate_id_token(token, expected_nonce="the-nonce")
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_matching_azp(httpx_mock):
+    cl = make_client(httpx_mock)
+    token = make_id_token(extra={"azp": CLIENT_ID})
+    claims = await cl.validate_id_token(token, expected_nonce="the-nonce")
+    assert claims["azp"] == CLIENT_ID
     await cl.aclose()
 
 

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,0 +1,291 @@
+"""Unit tests for the generic OIDC relying-party helper (kimai_mcp.oidc).
+
+Network I/O (discovery, JWKS, token endpoint) is faked with pytest-httpx.
+id_tokens are signed with a real RSA key (cryptography) so signature
+verification is exercised end-to-end.
+"""
+
+import json
+import time
+
+import pytest
+
+# PyJWT[crypto] is part of the optional [server] extra; skip these tests if the
+# server dependencies are not installed (e.g. a base/[dev]-only environment).
+jwt = pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+from cryptography.hazmat.primitives.asymmetric import rsa  # noqa: E402
+
+from kimai_mcp.oidc import (  # noqa: E402
+    OIDCClient,
+    OIDCConfig,
+    OIDCDiscoveryError,
+    OIDCTokenExchangeError,
+    OIDCValidationError,
+    generate_pkce_pair,
+)
+
+# Relax pytest-httpx strictness: discovery/JWKS responses are cached and may be
+# matched zero or many times depending on the test path.
+pytestmark = pytest.mark.httpx_mock(
+    assert_all_responses_were_requested=False,
+    can_send_already_matched_responses=True,
+)
+
+ISSUER = "https://idp.example.com"
+CLIENT_ID = "kimai-mcp-client"
+KID = "test-key-1"
+DISCOVERY_URL = f"{ISSUER}/.well-known/openid-configuration"
+AUTH_ENDPOINT = f"{ISSUER}/authorize"
+TOKEN_ENDPOINT = f"{ISSUER}/token"
+JWKS_URI = f"{ISSUER}/jwks"
+
+DISCOVERY_DOC = {
+    "issuer": ISSUER,
+    "authorization_endpoint": AUTH_ENDPOINT,
+    "token_endpoint": TOKEN_ENDPOINT,
+    "jwks_uri": JWKS_URI,
+}
+
+# A single RSA keypair for the whole module; a second, unrelated key for
+# bad-signature tests.
+_PRIV = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_OTHER_PRIV = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _jwks_for(priv, kid=KID):
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(priv.public_key()))
+    jwk.update({"kid": kid, "use": "sig", "alg": "RS256"})
+    return {"keys": [jwk]}
+
+
+JWKS = _jwks_for(_PRIV)
+
+
+def make_id_token(
+    priv=_PRIV,
+    *,
+    kid=KID,
+    alg="RS256",
+    iss=ISSUER,
+    aud=CLIENT_ID,
+    nonce="the-nonce",
+    email="alice@firma.de",
+    exp_delta=300,
+    iat_delta=0,
+    extra=None,
+):
+    now = int(time.time())
+    payload = {
+        "iss": iss,
+        "aud": aud,
+        "iat": now + iat_delta,
+        "exp": now + exp_delta,
+        "nonce": nonce,
+        "email": email,
+    }
+    if extra:
+        payload.update(extra)
+    if alg == "none":
+        return jwt.encode(payload, None, algorithm="none")
+    return jwt.encode(payload, priv, algorithm=alg, headers={"kid": kid})
+
+
+def make_client(httpx_mock, *, add_discovery=True, add_jwks=True, jwks=None, **config_kwargs):
+    if add_discovery:
+        httpx_mock.add_response(url=DISCOVERY_URL, json=DISCOVERY_DOC)
+    if add_jwks:
+        httpx_mock.add_response(url=JWKS_URI, json=jwks or JWKS)
+    cfg = OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID, **config_kwargs)
+    return OIDCClient(cfg)
+
+
+# ---------------------------------------------------------------------------
+# PKCE + identity extraction (no network)
+# ---------------------------------------------------------------------------
+
+
+def test_pkce_pair_is_s256():
+    import base64
+    import hashlib
+
+    verifier, challenge = generate_pkce_pair()
+    expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    assert challenge == expected
+
+
+def test_extract_identity_prefers_email():
+    cfg = OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID)
+    cl = OIDCClient(cfg)
+    assert cl.extract_identity({"email": "a@b.de", "preferred_username": "x"}) == "a@b.de"
+
+
+def test_extract_identity_username_fallback_requires_at():
+    cfg = OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID)
+    cl = OIDCClient(cfg)
+    assert cl.extract_identity({"preferred_username": "plainuser"}) is None
+    assert cl.extract_identity({"upn": "u@b.de"}) == "u@b.de"
+    assert cl.extract_identity({"sub": "123"}) is None
+
+
+def test_extract_identity_custom_claim():
+    cfg = OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID, identity_claims=["sub"])
+    cl = OIDCClient(cfg)
+    assert cl.extract_identity({"sub": "user-123", "email": "a@b.de"}) == "user-123"
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_is_cached(httpx_mock):
+    cl = make_client(httpx_mock, add_jwks=False)
+    m1 = await cl.discover()
+    m2 = await cl.discover()
+    assert m1.token_endpoint == TOKEN_ENDPOINT and m2.issuer == ISSUER
+    discovery_calls = [r for r in httpx_mock.get_requests() if "openid-configuration" in str(r.url)]
+    assert len(discovery_calls) == 1
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_discovery_issuer_mismatch_rejected(httpx_mock):
+    httpx_mock.add_response(url=DISCOVERY_URL, json={**DISCOVERY_DOC, "issuer": "https://evil.example.com"})
+    cl = OIDCClient(OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID))
+    with pytest.raises(OIDCDiscoveryError):
+        await cl.discover()
+    await cl.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Authorization URL + code exchange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_authorization_url(httpx_mock):
+    cl = make_client(httpx_mock, add_jwks=False)
+    url = await cl.build_authorization_url(
+        state="st", nonce="no", code_challenge="ch", redirect_uri="https://mcp.example.com/oauth/oidc/callback"
+    )
+    assert url.startswith(AUTH_ENDPOINT + "?")
+    assert "code_challenge_method=S256" in url
+    assert "client_id=kimai-mcp-client" in url
+    assert "state=st" in url and "nonce=no" in url
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_public_vs_confidential(httpx_mock):
+    # public client (no secret)
+    cl = make_client(httpx_mock, add_jwks=False)
+    httpx_mock.add_response(url=TOKEN_ENDPOINT, method="POST", json={"id_token": "x", "access_token": "y"})
+    out = await cl.exchange_code(code="abc", code_verifier="ver", redirect_uri="https://m/cb")
+    assert out["id_token"] == "x"
+    body = httpx_mock.get_requests(url=TOKEN_ENDPOINT)[-1].read().decode()
+    assert "code_verifier=ver" in body and "client_secret" not in body
+    await cl.aclose()
+
+    # confidential client (secret included)
+    cl2 = make_client(httpx_mock, add_discovery=False, add_jwks=False, client_secret="s3cr3t")
+    httpx_mock.add_response(url=TOKEN_ENDPOINT, method="POST", json={"id_token": "x"})
+    await cl2.exchange_code(code="abc", code_verifier="ver", redirect_uri="https://m/cb")
+    body2 = httpx_mock.get_requests(url=TOKEN_ENDPOINT)[-1].read().decode()
+    assert "client_secret=s3cr3t" in body2
+    await cl2.aclose()
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_error_status(httpx_mock):
+    cl = make_client(httpx_mock, add_jwks=False)
+    httpx_mock.add_response(url=TOKEN_ENDPOINT, method="POST", status_code=400, json={"error": "invalid_grant"})
+    with pytest.raises(OIDCTokenExchangeError):
+        await cl.exchange_code(code="abc", code_verifier="ver", redirect_uri="https://m/cb")
+    await cl.aclose()
+
+
+# ---------------------------------------------------------------------------
+# id_token validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_id_token_happy_path(httpx_mock):
+    cl = make_client(httpx_mock)
+    claims = await cl.validate_id_token(make_id_token(), expected_nonce="the-nonce")
+    assert claims["email"] == "alice@firma.de"
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_bad_signature(httpx_mock):
+    cl = make_client(httpx_mock)  # JWKS holds _PRIV's public key
+    token = make_id_token(_OTHER_PRIV)  # signed by a different key
+    with pytest.raises(OIDCValidationError):
+        await cl.validate_id_token(token, expected_nonce="the-nonce")
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_wrong_audience(httpx_mock):
+    cl = make_client(httpx_mock)
+    with pytest.raises(OIDCValidationError):
+        await cl.validate_id_token(make_id_token(aud="someone-else"), expected_nonce="the-nonce")
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_wrong_issuer(httpx_mock):
+    cl = make_client(httpx_mock)
+    with pytest.raises(OIDCValidationError):
+        await cl.validate_id_token(make_id_token(iss="https://evil.example.com"), expected_nonce="the-nonce")
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_expired(httpx_mock):
+    cl = make_client(httpx_mock)
+    with pytest.raises(OIDCValidationError):
+        await cl.validate_id_token(make_id_token(exp_delta=-3600), expected_nonce="the-nonce")
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_within_leeway(httpx_mock):
+    cl = make_client(httpx_mock, clock_skew_seconds=120)
+    # expired 30s ago, but within the 120s leeway
+    claims = await cl.validate_id_token(make_id_token(exp_delta=-30), expected_nonce="the-nonce")
+    assert claims["email"] == "alice@firma.de"
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_nonce_mismatch(httpx_mock):
+    cl = make_client(httpx_mock)
+    with pytest.raises(OIDCValidationError):
+        await cl.validate_id_token(make_id_token(nonce="wrong"), expected_nonce="the-nonce")
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_alg_none(httpx_mock):
+    # alg:none must be rejected before any network/JWKS lookup.
+    cl = make_client(httpx_mock, add_discovery=False, add_jwks=False)
+    with pytest.raises(OIDCValidationError):
+        await cl.validate_id_token(make_id_token(alg="none"), expected_nonce="the-nonce")
+    await cl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_validate_handles_key_rotation(httpx_mock):
+    # First JWKS lacks the token's kid; a refresh returns the right key set.
+    stale_jwks = _jwks_for(_OTHER_PRIV, kid="old-key")
+    httpx_mock.add_response(url=DISCOVERY_URL, json=DISCOVERY_DOC)
+    httpx_mock.add_response(url=JWKS_URI, json=stale_jwks)  # first fetch (cold cache)
+    httpx_mock.add_response(url=JWKS_URI, json=JWKS)  # forced refresh on kid miss
+    cl = OIDCClient(OIDCConfig(issuer=ISSUER, client_id=CLIENT_ID))
+    claims = await cl.validate_id_token(make_id_token(), expected_nonce="the-nonce")
+    assert claims["email"] == "alice@firma.de"
+    await cl.aclose()


### PR DESCRIPTION
## Summary

Adds an **optional** OIDC federated-login backend to the Streamable HTTP server's embedded OAuth 2.1 authorization server. Operators can now authenticate users against any standard OpenID Connect provider (Microsoft Entra ID / Azure AD, Keycloak, Auth0, Google, Okta, …) via `--auth-backend oidc`, instead of the built-in user-slug + `auth_secret` login form.

This is purely additive — with no OIDC config the server behaves byte-identically to today (`--auth-backend local` is the default).

## How it works

The server remains the OAuth 2.1 authorization server toward the MCP client (Claude.ai): **opaque tokens, Dynamic Client Registration, PKCE, refresh-token rotation and the `/token` endpoint are unchanged.** Only the *login step* federates:

1. `authorize()` redirects the browser to the OIDC provider (instead of the local form).
2. A new `/oauth/oidc/callback` route exchanges the code, verifies the `id_token` (JWKS signature, `iss`/`aud`/`exp`/`iat` + leeway, `nonce`; `alg:none`/HS\* rejected), and extracts the configured identity claim.
3. The identity is mapped to a configured user; the same internal authorization code (`subject = slug`) is issued, so everything downstream is identical to the local login.

Provider endpoints are obtained via OIDC Discovery (`<issuer>/.well-known/openid-configuration`) — nothing is hardcoded.

## Changes

- **New `src/kimai_mcp/oidc.py`** — provider-agnostic relying party: discovery + JWKS caching (with key-rotation refresh), PKCE, code exchange, `id_token` validation, identity extraction. `PyJWT` is imported lazily so a base install is unaffected.
- **`user_config.py`** — new optional `oidc_identity` field per user + `get_user_by_oidc_identity()` + `KIMAI_USER_<SLUG>_OIDC_IDENTITY` env override.
- **`oauth.py`** — backend-aware `authorize()`, the `/oauth/oidc/callback` handler, `routes()`, and cleanup of pending federated logins. Open-redirect safe (only the SDK-validated client `redirect_uri` is ever used).
- **`streamable_http_server.py`** — `--auth-backend` and `--oidc-*` CLI flags with `KIMAI_MCP_OIDC_*` env equivalents.
- **`pyproject.toml`** — `PyJWT[crypto]` added to the `[server]` extra (needed for RS256/ES256 `id_token` verification). CI now installs `[dev,server]`.
- **Tests** — `tests/test_oidc.py` (real RS256 signing + JWKS via `pytest-httpx`: happy path, bad signature, wrong `aud`/`iss`, expired/leeway, nonce mismatch, `alg:none`, key rotation, discovery caching) and an OIDC end-to-end flow in `tests/test_oauth.py`. The existing local-backend tests are unchanged.
- **README** — new "OIDC federated login" section.

## Mapping users

Each OIDC identity maps to a user via the new `oidc_identity` field in `users.json` (matched case-insensitively against `--oidc-identity-claim`, default `email`):

```json
{
  "x7Kp2mQ9wL4r": {
    "kimai_url": "https://kimai.example.com",
    "kimai_token": "...",
    "oidc_identity": "alice@example.com"
  }
}
```

Register `<public-url>/oauth/oidc/callback` as the redirect URI at the provider.

## Testing

`pytest tests/ -v` → 232 passed; `ruff check src/` clean. The OIDC unit tests `importorskip` PyJWT/cryptography so a `[dev]`-only environment skips rather than errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)