### PR TITLE
fix: entity create/update crashes serializing MetaField objects ('MetaField' object has no attribute 'get')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`entity` create/update raised `'MetaField' object has no attribute 'get'`** for projects, customers, and activities with custom meta fields. `create`/`update` return the `*Extended` models, whose `meta_fields` holds `MetaField` objects rather than dicts; the `serialize_*` branch was inverted and called dict's `.get()` on them. The entity is created before serialization, so the write succeeded despite the error. `list`/`get` were unaffected.
+
 ## [2.13.1] - 2026-06-19
 
 Build and CI maintenance only; no functional or API changes.

--- a/src/kimai_mcp/tools/entity_manager.py
+++ b/src/kimai_mcp/tools/entity_manager.py
@@ -603,8 +603,8 @@ class ProjectEntityHandler(BaseEntityHandler):
         if getattr(project, 'meta_fields', None):
             result += "Meta Fields:\n"
             for mf in project.meta_fields:
-                name = mf.get('name', mf.name) if hasattr(mf, 'name') else mf.get('name', 'Unknown')
-                value = mf.get('value', mf.value) if hasattr(mf, 'value') else mf.get('value', '')
+                name = mf.name if hasattr(mf, 'name') else mf.get('name', 'Unknown')
+                value = mf.value if hasattr(mf, 'value') else mf.get('value', '')
                 result += f"  - {name}: {value}\n"
         result += "\n"
         return result
@@ -675,8 +675,8 @@ class ActivityEntityHandler(BaseEntityHandler):
         if getattr(activity, 'meta_fields', None):
             result += "Meta Fields:\n"
             for mf in activity.meta_fields:
-                name = mf.get('name', mf.name) if hasattr(mf, 'name') else mf.get('name', 'Unknown')
-                value = mf.get('value', mf.value) if hasattr(mf, 'value') else mf.get('value', '')
+                name = mf.name if hasattr(mf, 'name') else mf.get('name', 'Unknown')
+                value = mf.value if hasattr(mf, 'value') else mf.get('value', '')
                 result += f"  - {name}: {value}\n"
         result += "\n"
         return result
@@ -765,8 +765,8 @@ class CustomerEntityHandler(BaseEntityHandler):
         if getattr(customer, 'meta_fields', None):
             result += "Meta Fields:\n"
             for mf in customer.meta_fields:
-                name = mf.get('name', mf.name) if hasattr(mf, 'name') else mf.get('name', 'Unknown')
-                value = mf.get('value', mf.value) if hasattr(mf, 'value') else mf.get('value', '')
+                name = mf.name if hasattr(mf, 'name') else mf.get('name', 'Unknown')
+                value = mf.value if hasattr(mf, 'value') else mf.get('value', '')
                 result += f"  - {name}: {value}\n"
         result += "\n"
 

--- a/tests/test_entity_serialization.py
+++ b/tests/test_entity_serialization.py
@@ -1,0 +1,26 @@
+"""Regression tests for entity meta-field serialization.
+
+create/update responses parse `metaFields` into `MetaField` objects (the
+`*Extended` models), unlike list/get which use the base models. Serializing a
+`MetaField` object previously raised `'MetaField' object has no attribute 'get'`
+because the dict/object branch was inverted.
+"""
+import pytest
+
+from kimai_mcp.models import ProjectExtended, CustomerExtended, ActivityExtended
+from kimai_mcp.tools.entity_manager import (
+    ProjectEntityHandler,
+    CustomerEntityHandler,
+    ActivityEntityHandler,
+)
+
+
+@pytest.mark.parametrize("handler_cls, model_cls, method", [
+    (ProjectEntityHandler, ProjectExtended, "serialize_project"),
+    (CustomerEntityHandler, CustomerExtended, "serialize_customer"),
+    (ActivityEntityHandler, ActivityExtended, "serialize_activity"),
+])
+def test_serialize_renders_metafield_objects(handler_cls, model_cls, method):
+    entity = model_cls(id=1, name="Test", metaFields=[{"name": "Festival", "value": "Nectar"}])
+    text = getattr(handler_cls(client=None), method)(entity)
+    assert "Festival: Nectar" in text


### PR DESCRIPTION
## Description

`entity` create/update raised `'MetaField' object has no attribute 'get'` for projects, customers, and activities with custom meta fields.

`create`/`update` return the `*Extended` models, whose `meta_fields` holds `MetaField` objects, while `list`/`get` use base models with no meta fields. The `serialize_*` loop had the dict/object branch inverted:

```python
name = mf.get('name', mf.name) if hasattr(mf, 'name') else mf.get('name', 'Unknown')
```

`hasattr(mf, 'name')` is `True` for a `MetaField`, so it took the `mf.get(...)` branch, but `MetaField` is a pydantic model with no `.get()`. Fixed to read the attribute when present and fall back to `.get()` only for dicts, in all three `serialize_*` handlers. The entity is created before serialization, so the write succeeds despite the error returned to the caller.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] `240 passed` locally
- [x] New parametrized regression test across all three handlers: fails on the old code with the exact `AttributeError`, passes with the fix
- [x] Reproduced against a live Kimai: create returns the error, the project is created anyway

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Changelog updated

---
🤖 Authored by Claude Code (Anthropic). Found by a downstream user creating projects with meta fields.
