### PR TITLE
feat: report in-handler tool errors with isError=true via ToolError (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] - 2026-06-30
+
+### Changed
+
+- **In-handler tool errors are now reported with `isError=true`.** v2.14.0 only marked caught exceptions; this extends the same behavior to the validation, unknown-action/type, and unsupported-operation conditions that handlers previously returned as a normal `Error: ...` `TextContent` (e.g. missing required parameters, invalid date formats, "Invoice creation is not supported", "Users cannot be deleted", unknown tool). Handlers now `raise ToolError` (new `tools/errors.py`), which both transports' `_call_tool` convert to a `CallToolResult(isError=True)` via the shared `error_result()` helper. The error message text is unchanged. (#18)
+- Batch operations that partially succeed (the `✓ Succeeded / ✗ Failed` summaries) and informational output (e.g. the timesheet `user_guide`, "No absences found") remain successful results, since they are not tool failures.
+
 ## [2.14.0] - 2026-06-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kimai-mcp"
-version = "2.14.0"
+version = "2.15.0"
 description = "MCP server for Kimai time-tracking API integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/kimai_mcp/__init__.py
+++ b/src/kimai_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Kimai MCP Server - Model Context Protocol server for Kimai time-tracking API integration."""
 
-__version__ = "2.14.0"
+__version__ = "2.15.0"

--- a/src/kimai_mcp/server.py
+++ b/src/kimai_mcp/server.py
@@ -28,6 +28,7 @@ from .client import KimaiClient, KimaiAPIError
 
 # Shared tool registry (single source of truth for both servers)
 from .tools.registry import all_tools, dispatch_tool
+from .tools.errors import ToolError
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -136,6 +137,10 @@ class KimaiMCPServer:
             # Route to the shared tool registry
             return await dispatch_tool(self.client, name, arguments)
 
+        except ToolError as e:
+            # Tool could not fulfill the request (bad input, unsupported op, etc.)
+            logger.info(f"Tool error in {name}: {e}")
+            return error_result(str(e))
         except KimaiAPIError as e:
             logger.error(f"Kimai API Error in tool {name}: {e.message} (Status: {e.status_code})")
             logger.error(f"Arguments were: {arguments}")

--- a/src/kimai_mcp/streamable_http_server.py
+++ b/src/kimai_mcp/streamable_http_server.py
@@ -50,6 +50,7 @@ from .client import KimaiClient, KimaiAPIError
 from .oauth import KimaiOAuthProvider
 from .oidc import OIDCConfig
 from .server import __version__, format_api_error, error_result
+from .tools.errors import ToolError
 from .user_config import UsersConfig, UserConfig
 from .security import (
     EnumerationProtection,
@@ -155,6 +156,10 @@ class UserMCPSession:
         try:
             return await dispatch_tool(self.kimai_client, name, arguments)
 
+        except ToolError as e:
+            # Tool could not fulfill the request (bad input, unsupported op, etc.)
+            logger.info(f"Tool error for user '{self.user_slug}' in {name}: {e}")
+            return error_result(str(e))
         except KimaiAPIError as e:
             logger.error(
                 f"Kimai API Error for user '{self.user_slug}' in tool {name}: "

--- a/src/kimai_mcp/tools/absence_manager.py
+++ b/src/kimai_mcp/tools/absence_manager.py
@@ -8,6 +8,7 @@ from ..models import AbsenceForm, AbsenceFilter
 from .absence_analytics import AbsenceAnalytics
 from .batch_utils import execute_batch, format_batch_result
 from .user_discovery import resolve_accessible_users
+from .errors import ToolError
 
 
 def absence_tool() -> Tool:
@@ -178,10 +179,9 @@ async def handle_absence(client: KimaiClient, **params) -> List[TextContent]:
     elif action == "batch_reject":
         return await _handle_batch_reject(client, params.get("ids", []))
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Valid actions: list, statistics, types, create, delete, approve, reject, request, attendance, batch_delete, batch_approve, batch_reject"
-        )]
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Valid actions: list, statistics, types, create, delete, approve, reject, request, attendance, batch_delete, batch_approve, batch_reject"
+        )
 
 
 async def _fetch_absences_for_users(
@@ -223,7 +223,7 @@ async def _handle_absence_list(client: KimaiClient, filters: Dict) -> List[TextC
             parsed_date = datetime.strptime(begin_date, "%Y-%m-%d")
             begin_date = parsed_date.strftime("%Y-%m-%dT00:00:00")
         except ValueError:
-            return [TextContent(type="text", text=f"Error: Invalid begin date format. Expected YYYY-MM-DD, got '{begin_date}'")]
+            raise ToolError(f"Error: Invalid begin date format. Expected YYYY-MM-DD, got '{begin_date}'")
     
     if end_date:
         try:
@@ -231,7 +231,7 @@ async def _handle_absence_list(client: KimaiClient, filters: Dict) -> List[TextC
             parsed_date = datetime.strptime(end_date, "%Y-%m-%d")
             end_date = parsed_date.strftime("%Y-%m-%dT23:59:59")
         except ValueError:
-            return [TextContent(type="text", text=f"Error: Invalid end date format. Expected YYYY-MM-DD, got '{end_date}'")]
+            raise ToolError(f"Error: Invalid end date format. Expected YYYY-MM-DD, got '{end_date}'")
     
     # Handle different user scopes
     absences = []
@@ -251,7 +251,7 @@ async def _handle_absence_list(client: KimaiClient, filters: Dict) -> List[TextC
         # Get absences for specific user
         user_filter = filters.get("user")
         if not user_filter:
-            return [TextContent(type="text", text="Error: 'user' parameter required when user_scope is 'specific'")]
+            raise ToolError("Error: 'user' parameter required when user_scope is 'specific'")
         
         absence_filter = AbsenceFilter(
             user=user_filter,
@@ -268,15 +268,14 @@ async def _handle_absence_list(client: KimaiClient, filters: Dict) -> List[TextC
             accessible_users = await resolve_accessible_users(client)
         except Exception as e:
             if isinstance(e, KimaiAPIError) and e.status_code == 403:
-                return [TextContent(
-                    type="text",
-                    text="Error: You don't have permission to view all users' absences.\n\n"
-                         "This requires either:\n"
-                         "- System Administrator role, or\n"
-                         "- Being a team lead (to see team members' absences)\n\n"
-                         "Use user_scope='self' to view your own absences, or\n"
-                         "user_scope='specific' with a user ID if you have permission for that user."
-                )]
+                raise ToolError(
+                    "Error: You don't have permission to view all users' absences.\n\n"
+                    "This requires either:\n"
+                    "- System Administrator role, or\n"
+                    "- Being a team lead (to see team members' absences)\n\n"
+                    "Use user_scope='self' to view your own absences, or\n"
+                    "user_scope='specific' with a user ID if you have permission for that user."
+                )
             raise
 
         # Now fetch absences for each accessible user (in parallel)
@@ -345,14 +344,14 @@ async def _handle_absence_statistics(
             parsed_date = datetime.strptime(begin_date, "%Y-%m-%d")
             begin_date = parsed_date.strftime("%Y-%m-%dT00:00:00")
         except ValueError:
-            return [TextContent(type="text", text=f"Error: Invalid begin date format. Expected YYYY-MM-DD, got '{begin_date}'")]
+            raise ToolError(f"Error: Invalid begin date format. Expected YYYY-MM-DD, got '{begin_date}'")
 
     if end_date:
         try:
             parsed_date = datetime.strptime(end_date, "%Y-%m-%d")
             end_date = parsed_date.strftime("%Y-%m-%dT23:59:59")
         except ValueError:
-            return [TextContent(type="text", text=f"Error: Invalid end date format. Expected YYYY-MM-DD, got '{end_date}'")]
+            raise ToolError(f"Error: Invalid end date format. Expected YYYY-MM-DD, got '{end_date}'")
 
     # Fetch absences based on user scope
     absences = []
@@ -370,7 +369,7 @@ async def _handle_absence_statistics(
     elif user_scope == "specific":
         user_filter = filters.get("user")
         if not user_filter:
-            return [TextContent(type="text", text="Error: 'user' parameter required when user_scope is 'specific'")]
+            raise ToolError("Error: 'user' parameter required when user_scope is 'specific'")
 
         absence_filter = AbsenceFilter(
             user=user_filter,
@@ -386,14 +385,13 @@ async def _handle_absence_statistics(
             accessible_users = await resolve_accessible_users(client)
         except Exception as e:
             if isinstance(e, KimaiAPIError) and e.status_code == 403:
-                return [TextContent(
-                    type="text",
-                    text="Error: You don't have permission to view all users' absences.\n\n"
-                         "This requires either:\n"
-                         "- System Administrator role, or\n"
-                         "- Being a team lead (to see team members' absences)\n\n"
-                         "Use user_scope='self' to view your own absence statistics."
-                )]
+                raise ToolError(
+                    "Error: You don't have permission to view all users' absences.\n\n"
+                    "This requires either:\n"
+                    "- System Administrator role, or\n"
+                    "- Being a team lead (to see team members' absences)\n\n"
+                    "Use user_scope='self' to view your own absence statistics."
+                )
             raise
 
         # Fetch absences for each accessible user (in parallel)
@@ -479,10 +477,9 @@ async def _handle_absence_create(client: KimaiClient, data: Dict) -> List[TextCo
     missing_fields = [field for field in required_fields if not data.get(field)]
 
     if missing_fields:
-        return [TextContent(
-            type="text",
-            text=f"Error: Missing required fields: {', '.join(missing_fields)}"
-        )]
+        raise ToolError(
+            f"Error: Missing required fields: {', '.join(missing_fields)}"
+        )
 
     # Parse dates
     start_date = datetime.strptime(data["date"], "%Y-%m-%d").date()
@@ -518,10 +515,9 @@ async def _handle_absence_create(client: KimaiClient, data: Dict) -> List[TextCo
                 else:
                     created_absences.append(absence_list)
             except Exception as e:
-                return [TextContent(
-                    type="text",
-                    text=f"Error creating absence chunk {chunk_start} - {chunk_end}: {str(e)}"
-                )]
+                raise ToolError(
+                    f"Error creating absence chunk {chunk_start} - {chunk_end}: {str(e)}"
+                )
 
         # Success message
         ids = ", ".join(str(a.id) for a in created_absences)
@@ -573,7 +569,7 @@ async def _handle_absence_create(client: KimaiClient, data: Dict) -> List[TextCo
 async def _handle_absence_delete(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle absence delete action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for delete action")]
+        raise ToolError("Error: 'id' parameter is required for delete action")
     
     await client.delete_absence(id)
     return [TextContent(type="text", text=f"Deleted absence ID {id}")]
@@ -582,7 +578,7 @@ async def _handle_absence_delete(client: KimaiClient, id: Optional[int]) -> List
 async def _handle_absence_approve(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle absence approve action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for approve action")]
+        raise ToolError("Error: 'id' parameter is required for approve action")
     
     await client.confirm_absence_approval(id)
     return [TextContent(type="text", text=f"Approved absence ID {id}")]
@@ -591,7 +587,7 @@ async def _handle_absence_approve(client: KimaiClient, id: Optional[int]) -> Lis
 async def _handle_absence_reject(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle absence reject action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for reject action")]
+        raise ToolError("Error: 'id' parameter is required for reject action")
     
     await client.reject_absence_approval(id)
     return [TextContent(type="text", text=f"Rejected absence ID {id}")]
@@ -600,7 +596,7 @@ async def _handle_absence_reject(client: KimaiClient, id: Optional[int]) -> List
 async def _handle_absence_request(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle absence request approval action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for request action")]
+        raise ToolError("Error: 'id' parameter is required for request action")
 
     await client.request_absence_approval(id)
     return [TextContent(type="text", text=f"Requested approval for absence ID {id}")]
@@ -649,10 +645,9 @@ async def _handle_attendance(
         try:
             check_date = datetime.strptime(date_str, "%Y-%m-%d").date()
         except ValueError:
-            return [TextContent(
-                type="text",
-                text=f"Error: Invalid date format. Expected YYYY-MM-DD, got '{date_str}'"
-            )]
+            raise ToolError(
+                f"Error: Invalid date format. Expected YYYY-MM-DD, got '{date_str}'"
+            )
     else:
         check_date = datetime.now().date()
 
@@ -661,12 +656,11 @@ async def _handle_attendance(
     all_users = await _get_accessible_users(client, user_scope)
 
     if not all_users:
-        return [TextContent(
-            type="text",
-            text="Error: Could not retrieve any users. You may need:\n"
-                 "- System Administrator role, or\n"
-                 "- Being a team lead (to see team members)"
-        )]
+        raise ToolError(
+            "Error: Could not retrieve any users. You may need:\n"
+            "- System Administrator role, or\n"
+            "- Being a team lead (to see team members)"
+        )
 
     # 3. Check absences for this day
     begin = check_date.strftime("%Y-%m-%dT00:00:00")
@@ -727,7 +721,7 @@ async def _handle_attendance(
 async def _handle_batch_delete(client: KimaiClient, ids: List[int]) -> List[TextContent]:
     """Batch delete multiple absences."""
     if not ids:
-        return [TextContent(type="text", text="Error: 'ids' parameter is required for batch_delete action")]
+        raise ToolError("Error: 'ids' parameter is required for batch_delete action")
 
     async def delete_one(id: int) -> int:
         await client.delete_absence(id)
@@ -741,7 +735,7 @@ async def _handle_batch_delete(client: KimaiClient, ids: List[int]) -> List[Text
 async def _handle_batch_approve(client: KimaiClient, ids: List[int]) -> List[TextContent]:
     """Batch approve multiple absences."""
     if not ids:
-        return [TextContent(type="text", text="Error: 'ids' parameter is required for batch_approve action")]
+        raise ToolError("Error: 'ids' parameter is required for batch_approve action")
 
     async def approve_one(id: int) -> int:
         await client.confirm_absence_approval(id)
@@ -755,7 +749,7 @@ async def _handle_batch_approve(client: KimaiClient, ids: List[int]) -> List[Tex
 async def _handle_batch_reject(client: KimaiClient, ids: List[int]) -> List[TextContent]:
     """Batch reject multiple absences."""
     if not ids:
-        return [TextContent(type="text", text="Error: 'ids' parameter is required for batch_reject action")]
+        raise ToolError("Error: 'ids' parameter is required for batch_reject action")
 
     async def reject_one(id: int) -> int:
         await client.reject_absence_approval(id)

--- a/src/kimai_mcp/tools/calendar_meta.py
+++ b/src/kimai_mcp/tools/calendar_meta.py
@@ -4,6 +4,7 @@ from typing import List, Dict
 from mcp.types import Tool, TextContent
 from ..client import KimaiClient
 from ..models import MetaFieldForm
+from .errors import ToolError
 
 
 def calendar_tool() -> Tool:
@@ -113,10 +114,9 @@ async def handle_calendar(client: KimaiClient, **params) -> List[TextContent]:
     elif calendar_type == "holidays":
         return await _handle_calendar_holidays(client, filters)
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown calendar type '{calendar_type}'. Valid types: absences, holidays"
-        )]
+        raise ToolError(
+            f"Error: Unknown calendar type '{calendar_type}'. Valid types: absences, holidays"
+        )
 
 
 async def handle_meta(client: KimaiClient, **params) -> List[TextContent]:
@@ -127,16 +127,15 @@ async def handle_meta(client: KimaiClient, **params) -> List[TextContent]:
     data = params.get("data", [])
     
     if not entity_id:
-        return [TextContent(type="text", text="Error: 'entity_id' parameter is required")]
-    
+        raise ToolError("Error: 'entity_id' parameter is required")
+
     if action != "update":
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Currently only 'update' is supported"
-        )]
-    
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Currently only 'update' is supported"
+        )
+
     if not data:
-        return [TextContent(type="text", text="Error: 'data' parameter is required for update action")]
+        raise ToolError("Error: 'data' parameter is required for update action")
     
     # Adapter for endpoints that accept only one meta field per request.
     async def _one_field_per_request(method, eid, fields):
@@ -157,10 +156,9 @@ async def handle_meta(client: KimaiClient, **params) -> List[TextContent]:
 
     handler = handlers.get(entity)
     if handler is None:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown entity type '{entity}'. Valid types: {', '.join(handlers)}"
-        )]
+        raise ToolError(
+            f"Error: Unknown entity type '{entity}'. Valid types: {', '.join(handlers)}"
+        )
 
     # Convert data to MetaFieldForm objects
     meta_fields = [MetaFieldForm(name=field["name"], value=field["value"]) for field in data]

--- a/src/kimai_mcp/tools/comment_tool.py
+++ b/src/kimai_mcp/tools/comment_tool.py
@@ -4,6 +4,7 @@ from typing import List
 from mcp.types import Tool, TextContent
 from ..client import KimaiClient
 from ..models import CommentForm
+from .errors import ToolError
 
 
 def comment_tool() -> Tool:
@@ -64,12 +65,11 @@ async def handle_comment(client: KimaiClient, **params) -> List[TextContent]:
     data = params.get("data", {})
 
     if entity not in ("project", "customer"):
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown entity type '{entity}'. Valid types: project, customer"
-        )]
+        raise ToolError(
+            f"Error: Unknown entity type '{entity}'. Valid types: project, customer"
+        )
     if entity_id is None:
-        return [TextContent(type="text", text="Error: 'entity_id' parameter is required")]
+        raise ToolError("Error: 'entity_id' parameter is required")
 
     if action == "list":
         comments = await client.get_comments(entity, entity_id)
@@ -77,7 +77,7 @@ async def handle_comment(client: KimaiClient, **params) -> List[TextContent]:
 
     elif action == "create":
         if not data.get("message"):
-            return [TextContent(type="text", text="Error: 'data.message' is required for create action")]
+            raise ToolError("Error: 'data.message' is required for create action")
         form = CommentForm(message=data["message"], pinned=data.get("pinned"))
         comment = await client.create_comment(entity, entity_id, form)
         pinned_info = " (pinned)" if comment.pinned else ""
@@ -88,22 +88,21 @@ async def handle_comment(client: KimaiClient, **params) -> List[TextContent]:
 
     elif action == "delete":
         if comment_id is None:
-            return [TextContent(type="text", text="Error: 'comment_id' parameter is required for delete action")]
+            raise ToolError("Error: 'comment_id' parameter is required for delete action")
         await client.delete_comment(entity, entity_id, comment_id)
         return [TextContent(type="text", text=f"Deleted comment ID {comment_id} from {entity} ID {entity_id}")]
 
     elif action == "pin":
         if comment_id is None:
-            return [TextContent(type="text", text="Error: 'comment_id' parameter is required for pin action")]
+            raise ToolError("Error: 'comment_id' parameter is required for pin action")
         comment = await client.pin_comment(entity, entity_id, comment_id)
         status = "pinned" if comment.pinned else "unpinned"
         return [TextContent(type="text", text=f"Comment ID {comment_id} is now {status}")]
 
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Valid actions: list, create, delete, pin"
-        )]
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Valid actions: list, create, delete, pin"
+        )
 
 
 def _format_comment_list(comments: List, entity: str, entity_id: int) -> str:

--- a/src/kimai_mcp/tools/config_info.py
+++ b/src/kimai_mcp/tools/config_info.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import List
 from mcp.types import Tool, TextContent
 from ..client import KimaiClient
+from .errors import ToolError
 
 
 def config_tool() -> Tool:
@@ -47,10 +48,9 @@ async def handle_config(client: KimaiClient, **params) -> List[TextContent]:
     elif config_type == "all":
         return await _handle_all_config(client)
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown config type '{config_type}'. Valid types: timesheet, colors, plugins, version, all"
-        )]
+        raise ToolError(
+            f"Error: Unknown config type '{config_type}'. Valid types: timesheet, colors, plugins, version, all"
+        )
 
 
 async def _handle_timesheet_config(client: KimaiClient) -> List[TextContent]:

--- a/src/kimai_mcp/tools/entity_manager.py
+++ b/src/kimai_mcp/tools/entity_manager.py
@@ -13,6 +13,7 @@ from ..models import (
 )
 from .batch_utils import execute_batch, format_batch_result
 from .user_discovery import resolve_accessible_users
+from .errors import ToolError
 
 logger = logging.getLogger(__name__)
 
@@ -430,39 +431,37 @@ async def handle_entity(client: KimaiClient, **params) -> List[TextContent]:
 
     handler = handlers.get(entity_type)
     if not handler:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown entity type '{entity_type}'. Valid types: {', '.join(handlers.keys())}"
-        )]
+        raise ToolError(
+            f"Error: Unknown entity type '{entity_type}'. Valid types: {', '.join(handlers.keys())}"
+        )
 
     # Execute action - errors propagate to the central handler in server.py
     if action == "list":
         return await handler.list(filters)
     elif action == "get":
         if not entity_id:
-            return [TextContent(type="text", text="Error: 'id' parameter is required for get action")]
+            raise ToolError("Error: 'id' parameter is required for get action")
         return await handler.get(entity_id)
     elif action == "create":
         if not data:
-            return [TextContent(type="text", text="Error: 'data' parameter is required for create action")]
+            raise ToolError("Error: 'data' parameter is required for create action")
         return await handler.create(data)
     elif action == "update":
         if not entity_id:
-            return [TextContent(type="text", text="Error: 'id' parameter is required for update action")]
+            raise ToolError("Error: 'id' parameter is required for update action")
         if not data:
-            return [TextContent(type="text", text="Error: 'data' parameter is required for update action")]
+            raise ToolError("Error: 'data' parameter is required for update action")
         return await handler.update(entity_id, data)
     elif action == "delete":
         if not entity_id:
-            return [TextContent(type="text", text="Error: 'id' parameter is required for delete action")]
+            raise ToolError("Error: 'id' parameter is required for delete action")
         return await handler.delete(entity_id)
     elif action == "lock_month":
         if entity_type != "user":
-            return [
-                TextContent(type="text", text="Error: 'lock_month' action is only available for user entities")]
+            raise ToolError("Error: 'lock_month' action is only available for user entities")
         month = params.get("month")
         if not month:
-            return [TextContent(type="text", text="Error: 'month' parameter is required for lock_month action")]
+            raise ToolError("Error: 'month' parameter is required for lock_month action")
 
         # Determine user IDs to process
         user_ids = params.get("ids", [])
@@ -475,14 +474,13 @@ async def handle_entity(client: KimaiClient, **params) -> List[TextContent]:
         elif entity_id:
             return await handler.lock_month(entity_id, month)
         else:
-            return [TextContent(type="text", text="Error: 'id', 'ids', or 'user_scope=all' is required for lock_month action")]
+            raise ToolError("Error: 'id', 'ids', or 'user_scope=all' is required for lock_month action")
     elif action == "unlock_month":
         if entity_type != "user":
-            return [
-                TextContent(type="text", text="Error: 'unlock_month' action is only available for user entities")]
+            raise ToolError("Error: 'unlock_month' action is only available for user entities")
         month = params.get("month")
         if not month:
-            return [TextContent(type="text", text="Error: 'month' parameter is required for unlock_month action")]
+            raise ToolError("Error: 'month' parameter is required for unlock_month action")
 
         # Determine user IDs to process
         user_ids = params.get("ids", [])
@@ -495,35 +493,25 @@ async def handle_entity(client: KimaiClient, **params) -> List[TextContent]:
         elif entity_id:
             return await handler.unlock_month(entity_id, month)
         else:
-            return [TextContent(type="text", text="Error: 'id', 'ids', or 'user_scope=all' is required for unlock_month action")]
+            raise ToolError("Error: 'id', 'ids', or 'user_scope=all' is required for unlock_month action")
     elif action == "batch_delete":
         ids = params.get("ids", [])
         if not ids:
-            return [TextContent(type="text", text="Error: 'ids' parameter is required for batch_delete action")]
+            raise ToolError("Error: 'ids' parameter is required for batch_delete action")
         return await _handle_batch_delete(handler, entity_type, ids)
     elif action == "set_preferences":
         if entity_type != "user":
-            return [TextContent(
-                type="text",
-                text="Error: 'set_preferences' action is only available for user entities"
-            )]
+            raise ToolError("Error: 'set_preferences' action is only available for user entities")
         preferences = params.get("preferences", [])
         if not preferences:
-            return [TextContent(
-                type="text",
-                text="Error: 'preferences' parameter is required for set_preferences action"
-            )]
+            raise ToolError("Error: 'preferences' parameter is required for set_preferences action")
         if not entity_id:
-            return [TextContent(
-                type="text",
-                text="Error: 'id' parameter is required for set_preferences action"
-            )]
+            raise ToolError("Error: 'id' parameter is required for set_preferences action")
         return await handler.set_preferences(entity_id, preferences)
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Valid actions: list, get, create, update, delete, lock_month, unlock_month, batch_delete, set_preferences"
-        )]
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Valid actions: list, get, create, update, delete, lock_month, unlock_month, batch_delete, set_preferences"
+        )
 
 
 async def _handle_batch_delete(handler: 'BaseEntityHandler', entity_type: str, ids: List[int]) -> List[TextContent]:
@@ -531,10 +519,9 @@ async def _handle_batch_delete(handler: 'BaseEntityHandler', entity_type: str, i
     # Check if entity type supports deletion
     non_deletable = ["user", "invoice"]
     if entity_type in non_deletable:
-        return [TextContent(
-            type="text",
-            text=f"Error: batch_delete is not supported for {entity_type} entities"
-        )]
+        raise ToolError(
+            f"Error: batch_delete is not supported for {entity_type} entities"
+        )
 
     # Map entity types to client delete methods
     delete_methods = {
@@ -548,10 +535,9 @@ async def _handle_batch_delete(handler: 'BaseEntityHandler', entity_type: str, i
 
     delete_method = delete_methods.get(entity_type)
     if not delete_method:
-        return [TextContent(
-            type="text",
-            text=f"Error: batch_delete is not supported for {entity_type} entities"
-        )]
+        raise ToolError(
+            f"Error: batch_delete is not supported for {entity_type} entities"
+        )
 
     async def delete_one(id: int) -> int:
         await delete_method(id)
@@ -637,10 +623,9 @@ class ProjectEntityHandler(BaseEntityHandler):
         required_fields = ["name", "customer"]
         missing = [field for field in required_fields if not data.get(field)]
         if missing:
-            return [TextContent(
-                type="text",
-                text=f"Error: Missing required project fields: {', '.join(missing)}"
-            )]
+            raise ToolError(
+                f"Error: Missing required project fields: {', '.join(missing)}"
+            )
         form = ProjectEditForm(**data)
         project = await self.client.create_project(form)
         return [TextContent(
@@ -799,10 +784,9 @@ class CustomerEntityHandler(BaseEntityHandler):
         required_fields = ["name", "country", "currency", "timezone"]
         missing = [field for field in required_fields if not data.get(field)]
         if missing:
-            return [TextContent(
-                type="text",
-                text=f"Error: Missing required customer fields: {', '.join(missing)}"
-            )]
+            raise ToolError(
+                f"Error: Missing required customer fields: {', '.join(missing)}"
+            )
 
         form = CustomerEditForm(**data)
         customer = await self.client.create_customer(form)
@@ -873,10 +857,9 @@ class UserEntityHandler(BaseEntityHandler):
         )]
 
     async def delete(self, id: int) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Users cannot be deleted. Use update with enabled=false to deactivate."
-        )]
+        raise ToolError(
+            "Error: Users cannot be deleted. Use update with enabled=false to deactivate."
+        )
 
     async def lock_month(self, user_id: int, month: str) -> List[TextContent]:
         """Lock working time months for a user."""
@@ -898,14 +881,13 @@ class UserEntityHandler(BaseEntityHandler):
                 user_ids = await self._resolve_all_user_ids()
             except Exception as e:
                 if isinstance(e, KimaiAPIError) and e.status_code == 403:
-                    return [TextContent(
-                        type="text",
-                        text="Error: You don't have permission to access all users.\n\n"
-                             "This requires either:\n"
-                             "- System Administrator role, or\n"
-                             "- Being a team lead (to access team members)\n\n"
-                             "Use 'ids' parameter to specify specific user IDs instead."
-                    )]
+                    raise ToolError(
+                        "Error: You don't have permission to access all users.\n\n"
+                        "This requires either:\n"
+                        "- System Administrator role, or\n"
+                        "- Being a team lead (to access team members)\n\n"
+                        "Use 'ids' parameter to specify specific user IDs instead."
+                    )
                 raise
 
         async def lock_one(uid: int) -> int:
@@ -937,14 +919,13 @@ class UserEntityHandler(BaseEntityHandler):
                 user_ids = await self._resolve_all_user_ids()
             except Exception as e:
                 if isinstance(e, KimaiAPIError) and e.status_code == 403:
-                    return [TextContent(
-                        type="text",
-                        text="Error: You don't have permission to access all users.\n\n"
-                             "This requires either:\n"
-                             "- System Administrator role, or\n"
-                             "- Being a team lead (to access team members)\n\n"
-                             "Use 'ids' parameter to specify specific user IDs instead."
-                    )]
+                    raise ToolError(
+                        "Error: You don't have permission to access all users.\n\n"
+                        "This requires either:\n"
+                        "- System Administrator role, or\n"
+                        "- Being a team lead (to access team members)\n\n"
+                        "Use 'ids' parameter to specify specific user IDs instead."
+                    )
                 raise
 
         async def unlock_one(uid: int) -> int:
@@ -1016,19 +997,18 @@ class UserEntityHandler(BaseEntityHandler):
                         "then set hours_per_week.\n"
                     )
 
-                return [TextContent(
-                    type="text",
-                    text=f"Error: Work Contract not configured for user {user_id}.\n\n"
-                         f"The user preferences endpoint returned 404, which means the Work Contract "
-                         f"has not been set up for this user in Kimai.\n\n"
-                         f"Recommended fix: upgrade Kimai to the release with the work-contract "
-                         f"auto-init fix (>= 2.61.0, PR #5894). The API then initializes "
-                         f"work-contract preferences automatically and this call will succeed.\n\n"
-                         f"Workaround for older Kimai (< 2.61.0): configure the work contract "
-                         f"once in the Kimai UI, then retry via the API:\n"
-                         f"  {base_url}/de/profile/{username_encoded}/contract\n"
-                         f"{hours_per_week_hint}"
-                )]
+                raise ToolError(
+                    f"Error: Work Contract not configured for user {user_id}.\n\n"
+                    f"The user preferences endpoint returned 404, which means the Work Contract "
+                    f"has not been set up for this user in Kimai.\n\n"
+                    f"Recommended fix: upgrade Kimai to the release with the work-contract "
+                    f"auto-init fix (>= 2.61.0, PR #5894). The API then initializes "
+                    f"work-contract preferences automatically and this call will succeed.\n\n"
+                    f"Workaround for older Kimai (< 2.61.0): configure the work contract "
+                    f"once in the Kimai UI, then retry via the API:\n"
+                    f"  {base_url}/de/profile/{username_encoded}/contract\n"
+                    f"{hours_per_week_hint}"
+                )
             raise  # Re-raise other errors
 
         result = f"Updated preferences for {user.username} (ID: {user.id})\n\n"
@@ -1122,10 +1102,9 @@ class TagEntityHandler(BaseEntityHandler):
         return [TextContent(type="text", text=result)]
 
     async def get(self, id: int) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Tags don't support individual retrieval. Use list instead."
-        )]
+        raise ToolError(
+            "Error: Tags don't support individual retrieval. Use list instead."
+        )
 
     async def create(self, data: Dict) -> List[TextContent]:
         form = TagEditForm(**data)
@@ -1136,10 +1115,9 @@ class TagEntityHandler(BaseEntityHandler):
         )]
 
     async def update(self, id: int, data: Dict) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Tags cannot be updated. Delete and recreate if needed."
-        )]
+        raise ToolError(
+            "Error: Tags cannot be updated. Delete and recreate if needed."
+        )
 
     async def delete(self, id: int) -> List[TextContent]:
         await self.client.delete_tag(id)
@@ -1194,22 +1172,19 @@ class InvoiceEntityHandler(BaseEntityHandler):
         return [TextContent(type="text", text=result)]
 
     async def create(self, data: Dict) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Invoice creation is not supported through this API."
-        )]
+        raise ToolError(
+            "Error: Invoice creation is not supported through this API."
+        )
 
     async def update(self, id: int, data: Dict) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Invoice updates are not supported through this API."
-        )]
+        raise ToolError(
+            "Error: Invoice updates are not supported through this API."
+        )
 
     async def delete(self, id: int) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Invoice deletion is not supported through this API."
-        )]
+        raise ToolError(
+            "Error: Invoice deletion is not supported through this API."
+        )
 
 
 class HolidayEntityHandler(BaseEntityHandler):
@@ -1232,22 +1207,19 @@ class HolidayEntityHandler(BaseEntityHandler):
         return [TextContent(type="text", text=result)]
 
     async def get(self, id: int) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Holidays don't support individual retrieval. Use list instead."
-        )]
+        raise ToolError(
+            "Error: Holidays don't support individual retrieval. Use list instead."
+        )
 
     async def create(self, data: Dict) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Holiday creation is managed by administrators."
-        )]
+        raise ToolError(
+            "Error: Holiday creation is managed by administrators."
+        )
 
     async def update(self, id: int, data: Dict) -> List[TextContent]:
-        return [TextContent(
-            type="text",
-            text="Error: Holiday updates are not supported through this API."
-        )]
+        raise ToolError(
+            "Error: Holiday updates are not supported through this API."
+        )
 
     async def delete(self, id: int) -> List[TextContent]:
         await self.client.delete_public_holiday(id)

--- a/src/kimai_mcp/tools/errors.py
+++ b/src/kimai_mcp/tools/errors.py
@@ -1,0 +1,20 @@
+"""Tool-layer error type shared by the consolidated tool handlers.
+
+Handlers raise :class:`ToolError` when they cannot fulfill a request (invalid
+or missing input, an unknown action/type, an unsupported operation, or a
+permission/discovery failure). Both servers' ``_call_tool`` catch it and return
+a ``CallToolResult(isError=True)`` (via ``server.error_result``), so programmatic
+MCP clients can detect the failure instead of mistaking the error text for a
+successful payload.
+
+This module intentionally has no imports so it can be imported from any tool
+module without creating an import cycle.
+"""
+
+
+class ToolError(Exception):
+    """A tool could not fulfill the request.
+
+    The message is surfaced verbatim to the MCP client as the error result's
+    text, so it should be human-readable and actionable.
+    """

--- a/src/kimai_mcp/tools/project_analysis.py
+++ b/src/kimai_mcp/tools/project_analysis.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from mcp.types import Tool, TextContent
 from ..client import KimaiClient, KimaiAPIError
 from ..models import TimesheetFilter, ProjectFilter
+from .errors import ToolError
 
 # Safety limit: stop fetching timesheets once this many entries were collected
 MAX_ANALYSIS_RESULTS = 10000
@@ -53,18 +54,16 @@ async def handle_analyze_project_team(client: KimaiClient, arguments: Dict[str, 
         if not matching_projects:
             # Load all projects only to present available options
             all_projects = await client.get_projects()
-            return [TextContent(
-                type="text",
-                text=f"❌ No project found matching '{project_name}'. Available projects:\n" +
-                     "\n".join([f"• {p.name}" for p in all_projects[:10]])
-            )]
-        
+            raise ToolError(
+                f"❌ No project found matching '{project_name}'. Available projects:\n" +
+                "\n".join([f"• {p.name}" for p in all_projects[:10]])
+            )
+
         if len(matching_projects) > 1:
             project_list = "\n".join([f"• {p.name} (ID: {p.id})" for p in matching_projects])
-            return [TextContent(
-                type="text", 
-                text=f"⚠️ Multiple projects found matching '{project_name}':\n{project_list}\n\nPlease be more specific."
-            )]
+            raise ToolError(
+                f"⚠️ Multiple projects found matching '{project_name}':\n{project_list}\n\nPlease be more specific."
+            )
         
         project = matching_projects[0]
         
@@ -77,33 +76,29 @@ async def handle_analyze_project_team(client: KimaiClient, arguments: Dict[str, 
             user_filter = None
         elif user_scope == 'specific':
             if 'user' not in arguments:
-                return [TextContent(
-                    type="text", 
-                    text="❌ Error: When user_scope is 'specific', you must provide a 'user' parameter."
-                )]
+                raise ToolError(
+                    "❌ Error: When user_scope is 'specific', you must provide a 'user' parameter."
+                )
             user_filter = arguments['user']
         elif user_scope == 'team':
             if 'team' not in arguments:
-                return [TextContent(
-                    type="text", 
-                    text="❌ Error: When user_scope is 'team', you must provide a 'team' parameter. Use team_list to see available teams."
-                )]
+                raise ToolError(
+                    "❌ Error: When user_scope is 'team', you must provide a 'team' parameter. Use team_list to see available teams."
+                )
             # For team scope, we'll need to get team members first
             try:
                 team = await client.get_team(arguments['team'])
                 team_user_ids = [str(member.user.id) for member in team.members]
                 if not team_user_ids:
-                    return [TextContent(
-                        type="text", 
-                        text=f"❌ Team ID {arguments['team']} has no members."
-                    )]
+                    raise ToolError(f"❌ Team ID {arguments['team']} has no members.")
                 # Note: Kimai API doesn't support multiple user IDs in filter, so we'll filter post-processing
                 user_filter = 'all'  # Get all and filter later
+            except ToolError:
+                raise
             except Exception as e:
-                return [TextContent(
-                    type="text", 
-                    text=f"❌ Error accessing team {arguments['team']}: {str(e)}"
-                )]
+                raise ToolError(
+                    f"❌ Error accessing team {arguments['team']}: {str(e)}"
+                )
         
         # 3. Get timesheets for this project with user filtering
         filters = TimesheetFilter(
@@ -130,21 +125,18 @@ async def handle_analyze_project_team(client: KimaiClient, arguments: Dict[str, 
                 timesheets = [ts for ts in timesheets if ts.user in team_user_ids_int]
         except KimaiAPIError as e:
             if e.status_code in (401, 403):
-                return [TextContent(
-                    type="text",
-                    text=f"❌ Insufficient permissions to access project '{project.name}' data.\n\n**Required permissions:**\n• `view_other_timesheet` - to see all team members\n• `view_user` - to access user information\n\n**Tip:** Try asking your Kimai admin to grant these permissions or use `user_scope: 'self'` to see only your own data."
-                )]
+                raise ToolError(
+                    f"❌ Insufficient permissions to access project '{project.name}' data.\n\n**Required permissions:**\n• `view_other_timesheet` - to see all team members\n• `view_user` - to access user information\n\n**Tip:** Try asking your Kimai admin to grant these permissions or use `user_scope: 'self'` to see only your own data."
+                )
             elif e.status_code == 404:
-                return [TextContent(
-                    type="text",
-                    text=f"❌ Project '{project.name}' was found but some related data is not accessible. This might indicate deleted/archived data."
-                )]
+                raise ToolError(
+                    f"❌ Project '{project.name}' was found but some related data is not accessible. This might indicate deleted/archived data."
+                )
             else:
-                # Re-raise unexpected errors with more context
-                return [TextContent(
-                    type="text",
-                    text=f"❌ API Error while analyzing project '{project.name}': {str(e)}\n\nPlease check your Kimai connection and try again."
-                )]
+                # Surface unexpected API errors with more context
+                raise ToolError(
+                    f"❌ API Error while analyzing project '{project.name}': {str(e)}\n\nPlease check your Kimai connection and try again."
+                )
 
         if not timesheets:
             return [TextContent(
@@ -154,10 +146,9 @@ async def handle_analyze_project_team(client: KimaiClient, arguments: Dict[str, 
 
         # Safety check: fetch was aborted because the dataset exceeds the limit
         if len(timesheets) >= MAX_ANALYSIS_RESULTS:
-            return [TextContent(
-                type="text",
-                text=f"⚠️ Dataset too large: more than {MAX_ANALYSIS_RESULTS} entries found for project '{project.name}' (fetch stopped at {len(timesheets)}).\n\nPlease narrow down the date range (currently {begin.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}) or filter by specific users to ensure optimal performance."
-            )]
+            raise ToolError(
+                f"⚠️ Dataset too large: more than {MAX_ANALYSIS_RESULTS} entries found for project '{project.name}' (fetch stopped at {len(timesheets)}).\n\nPlease narrow down the date range (currently {begin.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}) or filter by specific users to ensure optimal performance."
+            )
         
         # Create lookup dictionaries
         user_lookup = {}
@@ -253,6 +244,12 @@ async def handle_analyze_project_team(client: KimaiClient, arguments: Dict[str, 
 **Project Status:** Active with {len(timesheets)} logged entries""")
         
         return [TextContent(type="text", text="\n".join(result_parts))]
-        
+
+    except ToolError:
+        # Already a clean, client-facing error; let the central handler mark isError.
+        raise
+    except KimaiAPIError:
+        # Let the central handler format it via format_api_error (with isError).
+        raise
     except Exception as e:
-        return [TextContent(type="text", text=f"❌ Error during analysis: {str(e)}")]
+        raise ToolError(f"❌ Error during analysis: {str(e)}")

--- a/src/kimai_mcp/tools/rate_manager.py
+++ b/src/kimai_mcp/tools/rate_manager.py
@@ -4,6 +4,7 @@ from typing import List, Dict
 from mcp.types import Tool, TextContent
 from ..client import KimaiClient
 from ..models import RateForm
+from .errors import ToolError
 
 
 def rate_tool() -> Tool:
@@ -63,38 +64,36 @@ async def handle_rate(client: KimaiClient, **params) -> List[TextContent]:
     data = params.get("data", {})
     
     if not entity_id:
-        return [TextContent(type="text", text="Error: 'entity_id' parameter is required")]
-    
+        raise ToolError("Error: 'entity_id' parameter is required")
+
     # Route to appropriate handler
     handlers = {
         "customer": CustomerRateHandler(client),
         "project": ProjectRateHandler(client),
         "activity": ActivityRateHandler(client)
     }
-    
+
     handler = handlers.get(entity)
     if not handler:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown entity type '{entity}'. Valid types: customer, project, activity"
-        )]
-    
+        raise ToolError(
+            f"Error: Unknown entity type '{entity}'. Valid types: customer, project, activity"
+        )
+
     # Execute action - errors propagate to the central handler in server.py
     if action == "list":
         return await handler.list(entity_id)
     elif action == "add":
         if not data:
-            return [TextContent(type="text", text="Error: 'data' parameter is required for add action")]
+            raise ToolError("Error: 'data' parameter is required for add action")
         return await handler.add(entity_id, data)
     elif action == "delete":
         if not rate_id:
-            return [TextContent(type="text", text="Error: 'rate_id' parameter is required for delete action")]
+            raise ToolError("Error: 'rate_id' parameter is required for delete action")
         return await handler.delete(entity_id, rate_id)
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Valid actions: list, add, delete"
-        )]
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Valid actions: list, add, delete"
+        )
 
 
 class BaseRateHandler:

--- a/src/kimai_mcp/tools/registry.py
+++ b/src/kimai_mcp/tools/registry.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 from mcp.types import Tool, TextContent
 
 from ..client import KimaiClient
+from .errors import ToolError
 from .entity_manager import entity_tool, handle_entity
 from .timesheet_consolidated import timesheet_tool, timer_tool, handle_timesheet, handle_timer
 from .rate_manager import rate_tool, handle_rate
@@ -69,12 +70,11 @@ async def dispatch_tool(
     client: KimaiClient, name: str, arguments: Optional[Dict[str, Any]]
 ) -> List[TextContent]:
     """Route a tool call to its handler. Exceptions propagate to the caller's
-    error handling (KimaiAPIError -> format_api_error)."""
+    error handling (ToolError / KimaiAPIError -> error_result)."""
     entry = _REGISTRY.get(name)
     if entry is None:
-        return [TextContent(
-            type="text",
-            text=f"Unknown tool: {name}. Available tools: {', '.join(_REGISTRY)}",
-        )]
+        raise ToolError(
+            f"Unknown tool: {name}. Available tools: {', '.join(_REGISTRY)}"
+        )
     _, run = entry
     return await run(client, arguments or {})

--- a/src/kimai_mcp/tools/team_access_manager.py
+++ b/src/kimai_mcp/tools/team_access_manager.py
@@ -3,6 +3,7 @@
 from typing import List, Optional
 from mcp.types import Tool, TextContent
 from ..client import KimaiClient
+from .errors import ToolError
 
 
 def team_access_tool() -> Tool:
@@ -50,7 +51,7 @@ async def handle_team_access(client: KimaiClient, **params) -> List[TextContent]
     target_id = params.get("target_id")
     
     if not team_id:
-        return [TextContent(type="text", text="Error: 'team_id' parameter is required")]
+        raise ToolError("Error: 'team_id' parameter is required")
 
     # Errors propagate to the central handler in server.py
     if action == "add_member":
@@ -62,17 +63,16 @@ async def handle_team_access(client: KimaiClient, **params) -> List[TextContent]
     elif action == "revoke":
         return await _handle_revoke_access(client, team_id, target, target_id)
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Valid actions: add_member, remove_member, grant, revoke"
-        )]
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Valid actions: add_member, remove_member, grant, revoke"
+        )
 
 
 async def _handle_add_member(client: KimaiClient, team_id: int, user_id: Optional[int]) -> List[TextContent]:
     """Handle adding a member to a team."""
     if not user_id:
-        return [TextContent(type="text", text="Error: 'user_id' parameter is required for add_member action")]
-    
+        raise ToolError("Error: 'user_id' parameter is required for add_member action")
+
     await client.add_team_member(team_id, user_id)
     
     return [TextContent(
@@ -84,8 +84,8 @@ async def _handle_add_member(client: KimaiClient, team_id: int, user_id: Optiona
 async def _handle_remove_member(client: KimaiClient, team_id: int, user_id: Optional[int]) -> List[TextContent]:
     """Handle removing a member from a team."""
     if not user_id:
-        return [TextContent(type="text", text="Error: 'user_id' parameter is required for remove_member action")]
-    
+        raise ToolError("Error: 'user_id' parameter is required for remove_member action")
+
     await client.remove_team_member(team_id, user_id)
     
     return [TextContent(
@@ -97,10 +97,10 @@ async def _handle_remove_member(client: KimaiClient, team_id: int, user_id: Opti
 async def _handle_grant_access(client: KimaiClient, team_id: int, target: Optional[str], target_id: Optional[int]) -> List[TextContent]:
     """Handle granting access to a team."""
     if not target:
-        return [TextContent(type="text", text="Error: 'target' parameter is required for grant action")]
+        raise ToolError("Error: 'target' parameter is required for grant action")
     if not target_id:
-        return [TextContent(type="text", text="Error: 'target_id' parameter is required for grant action")]
-    
+        raise ToolError("Error: 'target_id' parameter is required for grant action")
+
     if target == "customer":
         await client.grant_team_customer_access(team_id, target_id)
         entity_type = "customer"
@@ -111,10 +111,9 @@ async def _handle_grant_access(client: KimaiClient, team_id: int, target: Option
         await client.grant_team_activity_access(team_id, target_id)
         entity_type = "activity"
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown target type '{target}'. Valid types: customer, project, activity"
-        )]
+        raise ToolError(
+            f"Error: Unknown target type '{target}'. Valid types: customer, project, activity"
+        )
     
     return [TextContent(
         type="text",
@@ -125,10 +124,10 @@ async def _handle_grant_access(client: KimaiClient, team_id: int, target: Option
 async def _handle_revoke_access(client: KimaiClient, team_id: int, target: Optional[str], target_id: Optional[int]) -> List[TextContent]:
     """Handle revoking access from a team."""
     if not target:
-        return [TextContent(type="text", text="Error: 'target' parameter is required for revoke action")]
+        raise ToolError("Error: 'target' parameter is required for revoke action")
     if not target_id:
-        return [TextContent(type="text", text="Error: 'target_id' parameter is required for revoke action")]
-    
+        raise ToolError("Error: 'target_id' parameter is required for revoke action")
+
     if target == "customer":
         await client.revoke_team_customer_access(team_id, target_id)
         entity_type = "customer"
@@ -139,10 +138,9 @@ async def _handle_revoke_access(client: KimaiClient, team_id: int, target: Optio
         await client.revoke_team_activity_access(team_id, target_id)
         entity_type = "activity"
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown target type '{target}'. Valid types: customer, project, activity"
-        )]
+        raise ToolError(
+            f"Error: Unknown target type '{target}'. Valid types: customer, project, activity"
+        )
     
     return [TextContent(
         type="text",

--- a/src/kimai_mcp/tools/timesheet_consolidated.py
+++ b/src/kimai_mcp/tools/timesheet_consolidated.py
@@ -9,6 +9,7 @@ from ..models import TimesheetEditForm, TimesheetFilter, MetaFieldForm
 from .timesheet_analytics import TimesheetAnalytics
 from .batch_utils import execute_batch, format_batch_result
 from .user_discovery import resolve_accessible_users
+from .errors import ToolError
 
 
 def timesheet_tool() -> Tool:
@@ -206,10 +207,9 @@ async def handle_timesheet(client: KimaiClient, **params) -> List[TextContent]:
     elif action == "batch_export":
         return await _handle_batch_export(client, params.get("ids", []))
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Valid actions: list, get, create, update, delete, duplicate, export_toggle, meta_update, user_guide, batch_delete, batch_export"
-        )]
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Valid actions: list, get, create, update, delete, duplicate, export_toggle, meta_update, user_guide, batch_delete, batch_export"
+        )
 
 
 async def handle_timer(client: KimaiClient, **params) -> List[TextContent]:
@@ -227,10 +227,9 @@ async def handle_timer(client: KimaiClient, **params) -> List[TextContent]:
     elif action == "recent":
         return await _handle_timer_recent(client, params.get("size", 10), params.get("begin"))
     else:
-        return [TextContent(
-            type="text",
-            text=f"Error: Unknown action '{action}'. Valid actions: start, stop, restart, active, recent"
-        )]
+        raise ToolError(
+            f"Error: Unknown action '{action}'. Valid actions: start, stop, restart, active, recent"
+        )
 
 
 # Timesheet action handlers
@@ -248,7 +247,7 @@ async def _handle_timesheet_list(client: KimaiClient, filters: Dict) -> List[Tex
     elif user_scope == "specific":
         user_filter = filters.get("user")
         if not user_filter:
-            return [TextContent(type="text", text="Error: 'user' parameter required when user_scope is 'specific'")]
+            raise ToolError("Error: 'user' parameter required when user_scope is 'specific'")
     elif user_scope == "all":
         user_filter = "all"  # API requires explicit "all" to return all users' timesheets
 
@@ -257,16 +256,16 @@ async def _handle_timesheet_list(client: KimaiClient, filters: Dict) -> List[Tex
         try:
             begin_datetime = datetime.fromisoformat(filters["begin"])
         except ValueError:
-            return [TextContent(type="text",
-                                text=f"Error: Invalid date time format for field begin '{filters['begin']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")]
+            raise ToolError(
+                f"Error: Invalid date time format for field begin '{filters['begin']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
 
     end_datetime = None
     if "end" in filters:
         try:
             end_datetime = datetime.fromisoformat(filters["end"])
         except ValueError:
-            return [TextContent(type="text",
-                                text=f"Error: Invalid date time format for field end '{filters['end']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")]
+            raise ToolError(
+                f"Error: Invalid date time format for field end '{filters['end']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
 
 
     if (
@@ -413,7 +412,7 @@ async def _handle_timesheet_list(client: KimaiClient, filters: Dict) -> List[Tex
 async def _handle_timesheet_get(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle timesheet get action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for get action")]
+        raise ToolError("Error: 'id' parameter is required for get action")
     
     ts = await client.get_timesheet(id)
     
@@ -455,8 +454,8 @@ async def _handle_timesheet_create(client: KimaiClient, data: Dict) -> List[Text
     from datetime import datetime
 
     if not data.get("project") or not data.get("activity"):
-        return [TextContent(type="text", text="Error: 'project' and 'activity' are required for create action")]
-    
+        raise ToolError("Error: 'project' and 'activity' are required for create action")
+
     # Keep tags as string - model expects comma-separated string
     tags_str = data.get("tags", "")
 
@@ -464,8 +463,8 @@ async def _handle_timesheet_create(client: KimaiClient, data: Dict) -> List[Text
         try:
             begin_datetime = datetime.fromisoformat(data["begin"])
         except ValueError:
-            return [TextContent(type="text",
-                                text=f"Error: Invalid date format for field begin '{data['begin']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")]
+            raise ToolError(
+                f"Error: Invalid date format for field begin '{data['begin']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
     else:
         begin_datetime = datetime.now(timezone.utc).replace(microsecond=0)
 
@@ -474,8 +473,8 @@ async def _handle_timesheet_create(client: KimaiClient, data: Dict) -> List[Text
         try:
             end_datetime = datetime.fromisoformat(data["end"])
         except ValueError:
-            return [TextContent(type="text",
-                                text=f"Error: Invalid date format for field end '{data['end']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")]
+            raise ToolError(
+                f"Error: Invalid date format for field end '{data['end']}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
     
     form = TimesheetEditForm(
         project=data["project"],
@@ -503,9 +502,9 @@ async def _handle_timesheet_create(client: KimaiClient, data: Dict) -> List[Text
 async def _handle_timesheet_update(client: KimaiClient, id: Optional[int], data: Dict) -> List[TextContent]:
     """Handle timesheet update action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for update action")]
+        raise ToolError("Error: 'id' parameter is required for update action")
     if not data:
-        return [TextContent(type="text", text="Error: 'data' parameter is required for update action")]
+        raise ToolError("Error: 'data' parameter is required for update action")
     
     # Parse tags if provided
     if "tags" in data:
@@ -525,7 +524,7 @@ async def _handle_timesheet_update(client: KimaiClient, id: Optional[int], data:
 async def _handle_timesheet_delete(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle timesheet delete action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for delete action")]
+        raise ToolError("Error: 'id' parameter is required for delete action")
     
     await client.delete_timesheet(id)
     return [TextContent(type="text", text=f"Deleted timesheet ID {id}")]
@@ -534,7 +533,7 @@ async def _handle_timesheet_delete(client: KimaiClient, id: Optional[int]) -> Li
 async def _handle_timesheet_duplicate(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle timesheet duplicate action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for duplicate action")]
+        raise ToolError("Error: 'id' parameter is required for duplicate action")
     
     ts = await client.duplicate_timesheet(id)
     return [TextContent(
@@ -546,7 +545,7 @@ async def _handle_timesheet_duplicate(client: KimaiClient, id: Optional[int]) ->
 async def _handle_timesheet_export_toggle(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle timesheet export toggle action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for export_toggle action")]
+        raise ToolError("Error: 'id' parameter is required for export_toggle action")
     
     ts = await client.toggle_timesheet_export(id)
     status = "exported" if ts.exported else "not exported"
@@ -559,9 +558,9 @@ async def _handle_timesheet_export_toggle(client: KimaiClient, id: Optional[int]
 async def _handle_timesheet_meta_update(client: KimaiClient, id: Optional[int], meta: List[Dict]) -> List[TextContent]:
     """Handle timesheet meta update action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for meta_update action")]
+        raise ToolError("Error: 'id' parameter is required for meta_update action")
     if not meta:
-        return [TextContent(type="text", text="Error: 'meta' parameter is required for meta_update action")]
+        raise ToolError("Error: 'meta' parameter is required for meta_update action")
     
     # API accepts one meta field per request - iterate through each field
     updated_count = 0
@@ -660,7 +659,7 @@ When using the timesheet tool with action='list', you can control which users' t
 async def _handle_timer_start(client: KimaiClient, data: Dict) -> List[TextContent]:
     """Handle timer start action."""
     if not data.get("project") or not data.get("activity"):
-        return [TextContent(type="text", text="Error: 'project' and 'activity' are required in data for start action")]
+        raise ToolError("Error: 'project' and 'activity' are required in data for start action")
     
     # Keep tags as string - model expects comma-separated string
     tags_str = data.get("tags", "")
@@ -684,7 +683,7 @@ async def _handle_timer_start(client: KimaiClient, data: Dict) -> List[TextConte
 async def _handle_timer_stop(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle timer stop action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for stop action")]
+        raise ToolError("Error: 'id' parameter is required for stop action")
     
     ts = await client.stop_timesheet(id)
     
@@ -698,7 +697,7 @@ async def _handle_timer_stop(client: KimaiClient, id: Optional[int]) -> List[Tex
 async def _handle_timer_restart(client: KimaiClient, id: Optional[int]) -> List[TextContent]:
     """Handle timer restart action."""
     if not id:
-        return [TextContent(type="text", text="Error: 'id' parameter is required for restart action")]
+        raise ToolError("Error: 'id' parameter is required for restart action")
     
     ts = await client.restart_timesheet(id)
     
@@ -743,7 +742,7 @@ async def _handle_timer_recent(client: KimaiClient, size: int, begin: Optional[s
         try:
             begin_datetime = datetime.fromisoformat(begin)
         except ValueError:
-            return [TextContent(type="text", text=f"Error: Invalid date format '{begin}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")]
+            raise ToolError(f"Error: Invalid date format '{begin}'. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
     
     # Use regular timesheet list with recent parameters
     filter_params = TimesheetFilter(
@@ -778,7 +777,7 @@ async def _handle_timer_recent(client: KimaiClient, size: int, begin: Optional[s
 async def _handle_batch_delete(client: KimaiClient, ids: List[int]) -> List[TextContent]:
     """Batch delete multiple timesheets."""
     if not ids:
-        return [TextContent(type="text", text="Error: 'ids' parameter is required for batch_delete action")]
+        raise ToolError("Error: 'ids' parameter is required for batch_delete action")
 
     async def delete_one(id: int) -> int:
         await client.delete_timesheet(id)
@@ -792,7 +791,7 @@ async def _handle_batch_delete(client: KimaiClient, ids: List[int]) -> List[Text
 async def _handle_batch_export(client: KimaiClient, ids: List[int]) -> List[TextContent]:
     """Batch mark multiple timesheets as exported."""
     if not ids:
-        return [TextContent(type="text", text="Error: 'ids' parameter is required for batch_export action")]
+        raise ToolError("Error: 'ids' parameter is required for batch_export action")
 
     async def export_one(id: int) -> int:
         await client.toggle_timesheet_export(id)

--- a/tests/test_call_tool_errors.py
+++ b/tests/test_call_tool_errors.py
@@ -12,12 +12,15 @@ is equivalent to asserting on what the client receives.
 """
 
 import pytest
+from unittest.mock import AsyncMock
 from mcp.types import CallToolResult
 
-from kimai_mcp.client import KimaiAPIError
+from kimai_mcp.client import KimaiAPIError, KimaiClient
 from kimai_mcp.server import KimaiMCPServer
 from kimai_mcp.streamable_http_server import UserMCPSession
 from kimai_mcp.user_config import UserConfig
+from kimai_mcp.tools.errors import ToolError
+from kimai_mcp.tools import entity_manager, rate_manager
 
 
 def _assert_error(result, *expected_substrings):
@@ -114,3 +117,63 @@ async def test_streamable_generic_exception_sets_iserror(monkeypatch):
     result = await session._call_tool("entity", {"type": "project", "action": "list"})
 
     _assert_error(result, "Error: boom")
+
+
+# ---------------------------------------------------------------------------
+# ToolError (in-handler validation / unsupported operations) -> isError=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_tool_error_sets_iserror(local_server, monkeypatch):
+    monkeypatch.setattr(
+        "kimai_mcp.server.dispatch_tool", _raise(ToolError("Error: bad input"))
+    )
+
+    result = await local_server._call_tool(
+        "entity", {"type": "project", "action": "list"}
+    )
+
+    _assert_error(result, "Error: bad input")
+
+
+@pytest.mark.asyncio
+async def test_streamable_tool_error_sets_iserror(monkeypatch):
+    session = _make_session()
+    session.kimai_client = object()  # sentinel so the not-initialized guard is skipped
+    monkeypatch.setattr(
+        "kimai_mcp.streamable_http_server.dispatch_tool",
+        _raise(ToolError("Error: bad input")),
+    )
+
+    result = await session._call_tool("entity", {"type": "project", "action": "list"})
+
+    _assert_error(result, "Error: bad input")
+
+
+# ---------------------------------------------------------------------------
+# Representative handlers raise ToolError (rather than returning "Error:" text)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entity_unknown_action_raises_tool_error():
+    client = AsyncMock(spec=KimaiClient)
+    with pytest.raises(ToolError, match="Unknown action"):
+        await entity_manager.handle_entity(client, type="project", action="frobnicate")
+
+
+@pytest.mark.asyncio
+async def test_entity_unsupported_operation_raises_tool_error():
+    client = AsyncMock(spec=KimaiClient)
+    with pytest.raises(ToolError, match="Invoice creation is not supported"):
+        await entity_manager.handle_entity(
+            client, type="invoice", action="create", data={"name": "x"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_rate_missing_entity_id_raises_tool_error():
+    client = AsyncMock(spec=KimaiClient)
+    with pytest.raises(ToolError, match="'entity_id' parameter is required"):
+        await rate_manager.handle_rate(client, entity="project", action="list")

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -24,6 +24,7 @@ from mcp.types import TextContent, Tool
 
 from kimai_mcp import models as m
 from kimai_mcp.client import KimaiClient
+from kimai_mcp.tools.errors import ToolError
 from kimai_mcp.tools import (
     absence_manager,
     calendar_meta,
@@ -259,11 +260,27 @@ CASES = []
 _TRACKED_KEYS = ("action", "type", "entity", "target")
 
 
-def _case(tool_name, handler, params, case_id):
+def _case(tool_name, handler, params, case_id, expect_error=False):
     for key in _TRACKED_KEYS:
         if key in params:
             EXERCISED[(tool_name, key)].add(params[key])
-    CASES.append(pytest.param(handler, params, id=case_id))
+    CASES.append(pytest.param(handler, params, expect_error, id=case_id))
+
+
+# (entity_type, action) combinations whose handler now raises ToolError instead
+# of returning an "Error: ..." TextContent (unsupported operations / hard API
+# limitations). The central _call_tool converts these to isError=True results.
+ENTITY_ERROR_CASES = {
+    ("user", "delete"),
+    ("tag", "get"),
+    ("tag", "update"),
+    ("invoice", "create"),
+    ("invoice", "update"),
+    ("invoice", "delete"),
+    ("holiday", "get"),
+    ("holiday", "create"),
+    ("holiday", "update"),
+}
 
 
 # --- entity tool -----------------------------------------------------------
@@ -319,28 +336,33 @@ for entity_type in ENTITY_TYPES:
         "entity", entity_manager.handle_entity,
         {"type": entity_type, "action": "list"},
         f"entity-{entity_type}-list",
+        expect_error=(entity_type, "list") in ENTITY_ERROR_CASES,
     )
     _case(
         "entity", entity_manager.handle_entity,
         {"type": entity_type, "action": "get", "id": 1},
         f"entity-{entity_type}-get",
+        expect_error=(entity_type, "get") in ENTITY_ERROR_CASES,
     )
     _case(
         "entity", entity_manager.handle_entity,
         {"type": entity_type, "action": "create",
          "data": ENTITY_CREATE_DATA[entity_type]},
         f"entity-{entity_type}-create",
+        expect_error=(entity_type, "create") in ENTITY_ERROR_CASES,
     )
     _case(
         "entity", entity_manager.handle_entity,
         {"type": entity_type, "action": "update", "id": 1,
          "data": ENTITY_UPDATE_DATA[entity_type]},
         f"entity-{entity_type}-update",
+        expect_error=(entity_type, "update") in ENTITY_ERROR_CASES,
     )
     _case(
         "entity", entity_manager.handle_entity,
         {"type": entity_type, "action": "delete", "id": 1},
         f"entity-{entity_type}-delete",
+        expect_error=(entity_type, "delete") in ENTITY_ERROR_CASES,
     )
 
 # user-only actions
@@ -381,6 +403,7 @@ _case(
     "entity", entity_manager.handle_entity,
     {"type": "user", "action": "batch_delete", "ids": [1, 2]},
     "entity-user-batch_delete",
+    expect_error=True,
 )
 
 # --- timesheet tool --------------------------------------------------------
@@ -609,17 +632,31 @@ def assert_valid_result(result):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handler,params", CASES)
-async def test_dispatch_smoke(handler, params):
+@pytest.mark.parametrize("handler,params,expect_error", CASES)
+async def test_dispatch_smoke(handler, params, expect_error):
     """Dispatch every action of every tool handler against a specced mock.
 
     A call to a non-existent KimaiClient method raises AttributeError and
     fails the test (this exact bug class occurred 5 times in the past).
+
+    Cases marked ``expect_error`` exercise unsupported operations / hard API
+    limitations, which now raise ``ToolError`` (the central _call_tool turns
+    these into ``isError=True`` results).
     """
     client = make_mock_client()
 
-    if handler is project_analysis.handle_analyze_project_team:
-        # This handler takes the arguments dict positionally (see server.py)
+    is_positional = handler is project_analysis.handle_analyze_project_team
+
+    if expect_error:
+        with pytest.raises(ToolError):
+            if is_positional:
+                # This handler takes the arguments dict positionally (see server.py)
+                await handler(client, params)
+            else:
+                await handler(client, **params)
+        return
+
+    if is_positional:
         result = await handler(client, params)
     else:
         result = await handler(client, **params)
@@ -745,7 +782,7 @@ async def test_registry_dispatch_routes_known_and_unknown():
     # A known tool routes to its handler and returns TextContent.
     result = await registry.dispatch_tool(client, "user_current", {})
     assert_valid_result(result)
-    # An unknown tool yields a clear error instead of raising.
-    unknown = await registry.dispatch_tool(client, "does_not_exist", {})
-    assert_valid_result(unknown)
-    assert "Unknown tool" in unknown[0].text
+    # An unknown tool raises ToolError, which the servers convert to an
+    # isError=True result.
+    with pytest.raises(ToolError, match="Unknown tool"):
+        await registry.dispatch_tool(client, "does_not_exist", {})


### PR DESCRIPTION
## Summary

Follow-up to v2.14.0 (#18). v2.14.0 set `isError=true` only for **caught exceptions** (`KimaiAPIError` / generic `Exception`). This PR extends the same behavior to the **~114 in-handler conditions** that previously returned an `Error: ...` `TextContent` as a normal, `isError=false` result, so a programmatic MCP client (e.g. a proxying gateway) can detect them:

- missing / invalid parameters, invalid date formats
- unknown action / type / target / entity / config
- unsupported operations (`Invoice creation is not supported`, `Users cannot be deleted`, `Tags cannot be updated`, holiday limitations)
- permission / discovery failures (403 hints, "Work Contract not configured" 404, "could not retrieve users")
- unknown tool at the dispatch level

## How

- New leaf module `src/kimai_mcp/tools/errors.py` defining `ToolError(Exception)` (no intra-package imports → no cycles).
- Handlers `raise ToolError(...)` instead of returning the error `TextContent`. **Message text is unchanged.**
- Both transports' `_call_tool` catch `ToolError` (ordered before `KimaiAPIError` / `Exception`) and convert it to `CallToolResult(isError=True)` via the shared `error_result()` helper added in v2.14.0.
- `project_analysis`'s whole-body catch-all now re-raises `ToolError` / `KimaiAPIError` before wrapping truly-unexpected errors, so the flag is never swallowed.

## Deliberately left as successful results (not errors)

- Batch **partial-success** summaries (`✓ Succeeded / ✗ Failed`) from `format_batch_result`.
- Informational / empty-but-valid output: "No absences found", "No timesheets found", the timesheet `user_guide`, "Absence was submitted, but the API returned no record".

## Tests

- `tests/test_tool_dispatch.py`: adds an `expect_error` flag; the 10 cases that now raise (`user` delete + batch_delete, `tag` get/update, `invoice` create/update/delete, `holiday` get/create/update) assert `pytest.raises(ToolError)`. The registry unknown-tool test now expects a raise.
- `tests/test_call_tool_errors.py`: new tests that a raised `ToolError` yields `isError=True` in both transports, plus direct-handler raise checks.
- **251 passed**, ruff clean.

## Review

Ran `/code-review max` (5 parallel finder/verifier agents): swallowed-raise control flow, AST-level message-preservation check (all 114 messages byte-identical), missed/wrong conversions, test-coverage correctness, and import/exception design. **Zero findings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)